### PR TITLE
fix: removed references to deprecated v1 Android embedding

### DIFF
--- a/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.kt
@@ -7,7 +7,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import android.content.pm.PackageManager.NameNotFoundException
 
 /** FlutterInappPurchasePlugin  */
@@ -95,11 +94,6 @@ class FlutterInappPurchasePlugin : FlutterPlugin, ActivityAware {
 
         fun getStore(): String {
            return if (!isAndroid && !isAmazon) "none" else if (isAndroid) "play_store" else "amazon"
-        }
-
-        fun registerWith(registrar: Registrar) {
-            val instance = FlutterInappPurchasePlugin()
-            instance.onAttached(registrar.context(), registrar.messenger())
         }
 
         private fun isPackageInstalled(ctx: Context, packageName: String): Boolean {


### PR DESCRIPTION
Fixes Unresolved reference 'Registrar' due to loss of support for v1 embedding