### PR TITLE
Duplicate class com.amazon.device.iap.PurchasingListener found in modules amazon-appstore-sdk-3.0.5.jar

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,8 @@ dependencies {
     def billing_version = "6.0.1"
 
     implementation "com.android.billingclient:billing-ktx:$billing_version"
-    implementation files('jars/in-app-purchasing-2.0.76.jar')
+    // implementation files('jars/in-app-purchasing-2.0.76.jar')
+    implementation 'com.amazon.device:amazon-appstore-sdk:3.+'
     implementation 'androidx.annotation:annotation:1.6.0'
 }
 


### PR DESCRIPTION
   > Duplicate class com.amazon.device.iap.PurchasingListener found in modules amazon-appstore-sdk-3.0.5.jar -> jetified-amazon-appstore-sdk-3.0.5 (com.amazon.device:amazon-appstore-sdk:3.0.5) and in-app-purchasing-2.0.76.jar -> jetified-in-app-purchasing-2.0.76 (in-app-purchasing-2.0.76.jar)


Fixed Above Issue