### PR TITLE
fix: Fix Unresolved reference Registrar error on Android build

### DIFF
--- a/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.kt
@@ -7,7 +7,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import android.content.pm.PackageManager.NameNotFoundException
 
 /** FlutterInappPurchasePlugin  */
@@ -94,12 +93,7 @@ class FlutterInappPurchasePlugin : FlutterPlugin, ActivityAware {
         private var isAmazon = false
 
         fun getStore(): String {
-           return if (!isAndroid && !isAmazon) "none" else if (isAndroid) "play_store" else "amazon"
-        }
-
-        fun registerWith(registrar: Registrar) {
-            val instance = FlutterInappPurchasePlugin()
-            instance.onAttached(registrar.context(), registrar.messenger())
+            return if (!isAndroid && !isAmazon) "none" else if (isAndroid) "play_store" else "amazon"
         }
 
         private fun isPackageInstalled(ctx: Context, packageName: String): Boolean {


### PR DESCRIPTION
I got the following error on the Flutter `3.29.0` version.

<img width="1540" alt="スクリーンショット 2025-02-22 14 50 17" src="https://github.com/user-attachments/assets/c776acdd-922e-4bbd-9603-98add977dd80" />

Recently, Flutter removes `PluginRegistry.Registrar`.

- https://docs.flutter.dev/release/breaking-changes/plugin-api-migration

So, I remove it.