### PR TITLE
fix: deprecate initialize() method and fix iOS type casting issue

### DIFF
--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -492,13 +492,15 @@ class FlutterInappPurchase {
   }
 
   /// Initializes iap features for both `Android` and `iOS`.
+  @Deprecated('Use initConnection() instead. Will be removed in version 7.0.0')
   Future<String?> initialize() async {
     if (_platform.isAndroid) {
       await _setPurchaseListener();
       return await _channel.invokeMethod('initConnection');
     } else if (_platform.isIOS) {
       await _setPurchaseListener();
-      return await _channel.invokeMethod('canMakePayments');
+      final canMakePayments = await _channel.invokeMethod('canMakePayments');
+      return canMakePayments.toString();
     }
     throw PlatformException(
         code: _platform.operatingSystem, message: "platform not supported");


### PR DESCRIPTION
## Summary
- Add @Deprecated annotation to initialize() method pointing to initConnection()
- Fix iOS type casting issue by converting boolean to string
- This resolves the runtime error: type 'bool' is not a subtype of type 'String?'

## Breaking Change
Users should migrate from `initialize()` to `initConnection()`. The deprecated method will be removed in version 7.0.0.

## Problem
The `initialize()` method on iOS calls `canMakePayments` which returns a boolean, but the method signature expects `String?`, causing a type casting error.

## Solution
1. Deprecate the `initialize()` method in favor of `initConnection()`
2. Fix the immediate issue by converting the boolean to string
3. All documentation has been updated to use `initConnection()` (in separate PR)

## Test
Tested on real iOS device with sandbox environment - no more type casting errors.