### PR TITLE
refactor: clean up deprecated APIs for v6.1.0

### DIFF
--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# This podspec is NOT to be published. It is only used as a local source!
+# This is a generated file; do not edit or check into version control.
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'A UI toolkit for beautiful and fast apps.'
+  s.homepage         = 'https://flutter.dev'
+  s.license          = { :type => 'BSD' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '13.0'
+  # Framework linking is handled by Flutter tooling, not CocoaPods.
+  # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
+  s.vendored_frameworks = 'path/to/nothing'
+end

--- a/example/lib/src/screens/available_purchases_screen.dart
+++ b/example/lib/src/screens/available_purchases_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
@@ -16,7 +15,7 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
   final FlutterInappPurchase _iap = FlutterInappPurchase.instance;
 
   List<Purchase> _availablePurchases = [];
-  List<PurchasedItem> _purchaseHistory = [];
+  List<Purchase> _purchaseHistory = [];
   bool _loading = false;
   bool _connected = false;
   String? _error;
@@ -67,14 +66,14 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
 
     try {
       // Load available purchases (non-consumed)
-      final availablePurchases = await _iap.getAvailablePurchases();
+      final availablePurchases = await _iap.getActivePurchases();
 
       // Load purchase history
-      final purchaseHistory = await _iap.getPurchaseHistory();
+      final purchaseHistory = await _iap.getPurchaseHistories();
 
       setState(() {
         _availablePurchases = availablePurchases;
-        _purchaseHistory = purchaseHistory ?? [];
+        _purchaseHistory = purchaseHistory;
       });
     } catch (e) {
       setState(() {
@@ -95,7 +94,7 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
     });
 
     try {
-      final restored = await _iap.getAvailablePurchases();
+      final restored = await _iap.getActivePurchases();
       setState(() {
         _availablePurchases = restored;
       });
@@ -208,7 +207,7 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
     );
   }
 
-  Widget _buildPurchaseHistoryItem(PurchasedItem item) {
+  Widget _buildPurchaseHistoryItem(Purchase item) {
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
       child: Padding(
@@ -221,7 +220,7 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
               children: [
                 Expanded(
                   child: Text(
-                    item.productId ?? 'Unknown Product',
+                    item.productId.isEmpty ? 'Unknown Product' : item.productId,
                     style: const TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.w600,

--- a/example/lib/src/screens/debug_purchases_screen.dart
+++ b/example/lib/src/screens/debug_purchases_screen.dart
@@ -36,7 +36,7 @@ class _DebugPurchasesScreenState extends State<DebugPurchasesScreen> {
       await Future<void>.delayed(const Duration(seconds: 1));
 
       // Get all available purchases
-      final purchases = await _iap.getAvailablePurchases();
+      final purchases = await _iap.getActivePurchases();
 
       setState(() {
         _purchases = purchases;

--- a/example/lib/src/screens/subscription_flow_screen.dart
+++ b/example/lib/src/screens/subscription_flow_screen.dart
@@ -498,7 +498,7 @@ Platform: ${error.platform}
                           onPressed: () {
                             setState(() {
                               _purchaseResult = null;
-                                            });
+                            });
                           },
                         ),
                       ],

--- a/example/lib/src/screens/subscription_flow_screen.dart
+++ b/example/lib/src/screens/subscription_flow_screen.dart
@@ -26,8 +26,6 @@ class _SubscriptionFlowScreenState extends State<SubscriptionFlowScreen> {
   bool _isConnecting = true;
   bool _isLoadingProducts = false;
   String? _purchaseResult;
-  String? _initError;
-  Purchase? _currentPurchase;
   StreamSubscription<Purchase>? _purchaseUpdatedSubscription;
   StreamSubscription<PurchaseError>? _purchaseErrorSubscription;
 
@@ -58,9 +56,7 @@ class _SubscriptionFlowScreenState extends State<SubscriptionFlowScreen> {
       });
 
       if (!_connected) {
-        setState(() {
-          _initError = 'Failed to connect to store';
-        });
+        debugPrint('Failed to connect to store');
         return;
       }
 
@@ -102,7 +98,7 @@ class _SubscriptionFlowScreenState extends State<SubscriptionFlowScreen> {
         debugPrint('TransactionId: ${purchase.transactionId}');
         _handlePurchaseUpdate(purchase);
       },
-      onError: (error) {
+      onError: (Object error) {
         debugPrint('❌ Subscription stream error: $error');
       },
     );
@@ -125,7 +121,6 @@ class _SubscriptionFlowScreenState extends State<SubscriptionFlowScreen> {
 
     setState(() {
       _isProcessing = false;
-      _currentPurchase = purchase;
 
       // Format subscription result like KMP-IAP
       _purchaseResult = '''
@@ -195,7 +190,7 @@ Platform: ${error.platform}
 
   Future<void> _loadActiveSubscriptions() async {
     try {
-      final purchases = await _iap.getAvailablePurchases();
+      final purchases = await _iap.getActivePurchases();
       setState(() {
         _activeSubscriptions = purchases
             .where((p) => subscriptionIds.contains(p.productId))
@@ -503,8 +498,7 @@ Platform: ${error.platform}
                           onPressed: () {
                             setState(() {
                               _purchaseResult = null;
-                              _currentPurchase = null;
-                            });
+                                            });
                           },
                         ),
                       ],

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -566,8 +566,6 @@ class FlutterInappPurchase
     }
   }
 
-
-
   // Helper methods
   iap_types.BaseProduct _parseProductFromNative(
     Map<String, dynamic> json,
@@ -758,7 +756,6 @@ class FlutterInappPurchase
 
   // Original API methods (with deprecation annotations where needed)
 
-
   Future<bool> isReady() async {
     if (_platform.isAndroid) {
       return (await _channel.invokeMethod<bool?>('isReady')) ?? false;
@@ -771,8 +768,6 @@ class FlutterInappPurchase
       message: 'platform not supported',
     );
   }
-
-
 
   Future<Store> getStore() async {
     if (_platform.isIOS) {
@@ -872,7 +867,6 @@ class FlutterInappPurchase
     return items.map((item) => _convertToPurchase(item)).toList();
   }
 
-
   /// Request a subscription
   Future<dynamic> requestSubscription(
     String productId, {
@@ -903,10 +897,6 @@ class FlutterInappPurchase
     );
   }
 
-
-
-
-
   Future<List<iap_types.PurchasedItem>?> getPendingTransactionsIOS() async {
     if (_platform.isIOS) {
       dynamic result = await _channel.invokeMethod('getPendingTransactions');
@@ -915,7 +905,6 @@ class FlutterInappPurchase
     }
     return [];
   }
-
 
   @override
   Future<bool> consumePurchaseAndroid({required String purchaseToken}) async {
@@ -1003,7 +992,6 @@ class FlutterInappPurchase
     );
   }
 
-
   Future<List<iap_types.IAPItem>> getAppStoreInitiatedProducts() async {
     if (_platform.isAndroid) {
       return <iap_types.IAPItem>[];
@@ -1037,7 +1025,6 @@ class FlutterInappPurchase
       body: json.encode(receiptBody),
     );
   }
-
 
   @override
   Future<Map<String, dynamic>?> validateReceiptAndroid({
@@ -1157,7 +1144,6 @@ class FlutterInappPurchase
       ..close();
     _purchaseErrorController = null;
   }
-
 
   // flutter IAP compatible methods
 

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -251,24 +251,30 @@ class FlutterInappPurchase
         }
 
         if (iosRequest.withOffer != null) {
-          await requestProductWithOfferIOS(
-            iosRequest.sku,
-            iosRequest.appAccountToken ?? '',
-            iosRequest.withOffer!.toJson(),
+          await _channel.invokeMethod(
+            'requestProductWithOfferIOS',
+            <String, dynamic>{
+              'sku': iosRequest.sku,
+              'forUser': iosRequest.appAccountToken ?? '',
+              'withOffer': iosRequest.withOffer!.toJson(),
+            },
           );
         } else if (iosRequest.quantity != null && iosRequest.quantity! > 1) {
-          await requestPurchaseWithQuantityIOS(
-            iosRequest.sku,
-            iosRequest.quantity!,
+          await _channel.invokeMethod(
+            'requestProductWithQuantityIOS',
+            <String, dynamic>{
+              'sku': iosRequest.sku,
+              'quantity': iosRequest.quantity!.toString(),
+            },
           );
         } else {
           if (type == iap_types.PurchaseType.subs) {
             await requestSubscription(iosRequest.sku);
           } else {
-            await _requestPurchaseOld(
-              iosRequest.sku,
-              obfuscatedAccountId: iosRequest.appAccountToken,
-            );
+            await _channel.invokeMethod('buyProduct', <String, dynamic>{
+              'sku': iosRequest.sku,
+              'forUser': iosRequest.appAccountToken,
+            });
           }
         }
       } else if (_platform.isAndroid) {
@@ -293,12 +299,13 @@ class FlutterInappPurchase
                 androidRequest.obfuscatedProfileIdAndroid,
           );
         } else {
-          await _requestPurchaseOld(
-            sku,
-            obfuscatedAccountId: androidRequest.obfuscatedAccountIdAndroid,
-            obfuscatedProfileIdAndroid:
-                androidRequest.obfuscatedProfileIdAndroid,
-          );
+          await _channel.invokeMethod('buyItemByType', <String, dynamic>{
+            'type': TypeInApp.inapp.name,
+            'productId': sku,
+            'prorationMode': -1,
+            'obfuscatedAccountId': androidRequest.obfuscatedAccountIdAndroid,
+            'obfuscatedProfileId': androidRequest.obfuscatedProfileIdAndroid,
+          });
         }
       }
     } catch (e) {
@@ -369,8 +376,9 @@ class FlutterInappPurchase
     await requestPurchase(request: request, type: type);
   }
 
-  /// Get available purchases (flutter IAP compatible)
-  Future<List<iap_types.Purchase>> getAvailablePurchases() async {
+  /// Get non-consumed purchases (active purchases that haven't been finished)
+  /// Returns purchases that are still pending acknowledgment or consumption
+  Future<List<iap_types.Purchase>> getActivePurchases() async {
     if (!_isInitialized) {
       throw iap_types.PurchaseError(
         code: iap_types.ErrorCode.eNotInitialized,
@@ -402,21 +410,21 @@ class FlutterInappPurchase
 
         return allPurchases.map((item) => _convertToPurchase(item)).toList();
       } else if (_platform.isIOS) {
-        final purchases = await getAvailableItemsIOS();
-        return purchases?.map((item) => _convertToPurchase(item)).toList() ??
-            [];
+        // On iOS, use the internal method to get available items
+        return await _getAvailableItems();
       }
       return [];
     } catch (e) {
       throw iap_types.PurchaseError(
         code: iap_types.ErrorCode.eServiceError,
-        message: 'Failed to get available purchases: ${e.toString()}',
+        message: 'Failed to get active purchases: ${e.toString()}',
         platform: iap_types.getCurrentPlatform(),
       );
     }
   }
 
-  /// Get purchase histories (flutter IAP compatible)
+  /// Get complete purchase histories
+  /// Returns all purchases including consumed and finished ones
   Future<List<iap_types.Purchase>> getPurchaseHistories() async {
     if (!_isInitialized) {
       throw iap_types.PurchaseError(
@@ -427,8 +435,32 @@ class FlutterInappPurchase
     }
 
     try {
-      final history = await getPurchaseHistory();
-      return history?.map((item) => _convertToPurchase(item)).toList() ?? [];
+      final List<iap_types.PurchasedItem> history = [];
+
+      if (_platform.isAndroid) {
+        // Get purchase history for consumables
+        final dynamic inappHistory = await _channel.invokeMethod(
+          'getPurchaseHistoryByType',
+          <String, dynamic>{'type': TypeInApp.inapp.name},
+        );
+        final inappItems = extractPurchased(inappHistory) ?? [];
+        history.addAll(inappItems);
+
+        // Get purchase history for subscriptions
+        final dynamic subsHistory = await _channel.invokeMethod(
+          'getPurchaseHistoryByType',
+          <String, dynamic>{'type': TypeInApp.subs.name},
+        );
+        final subsItems = extractPurchased(subsHistory) ?? [];
+        history.addAll(subsItems);
+      } else if (_platform.isIOS) {
+        // On iOS, getAvailableItems returns the purchase history
+        dynamic result = await _channel.invokeMethod('getAvailableItems');
+        final items = extractPurchased(json.encode(result)) ?? [];
+        history.addAll(items);
+      }
+
+      return history.map((item) => _convertToPurchase(item)).toList();
     } catch (e) {
       throw iap_types.PurchaseError(
         code: iap_types.ErrorCode.eServiceError,
@@ -534,34 +566,7 @@ class FlutterInappPurchase
     }
   }
 
-  /// Legacy method for backward compatibility
-  Future<void> deepLinkToSubscriptionsAndroidLegacy({
-    required String sku,
-    required String packageName,
-  }) async {
-    await deepLinkToSubscriptionsAndroid(sku: sku);
-  }
 
-  /// Android specific: Acknowledge purchase (flutter IAP compatible)
-  @override
-  @Deprecated('Use finishTransaction() instead. Will be removed in 6.0.0')
-  Future<bool> acknowledgePurchaseAndroid({
-    required String purchaseToken,
-  }) async {
-    if (!_platform.isAndroid) {
-      return false;
-    }
-
-    try {
-      final result = await channel.invokeMethod<bool>('acknowledgePurchase', {
-        'purchaseToken': purchaseToken,
-      });
-      return result ?? false;
-    } catch (error) {
-      debugPrint('Error acknowledging purchase: $error');
-      return false;
-    }
-  }
 
   // Helper methods
   iap_types.BaseProduct _parseProductFromNative(
@@ -635,7 +640,7 @@ class FlutterInappPurchase
     if (json == null) return null;
     final list = json as List<dynamic>;
     return list
-        .map((e) => iap_types.DiscountIOS.fromJSON(e as Map<String, dynamic>))
+        .map((e) => iap_types.DiscountIOS.fromJson(e as Map<String, dynamic>))
         .toList();
   }
 
@@ -753,22 +758,6 @@ class FlutterInappPurchase
 
   // Original API methods (with deprecation annotations where needed)
 
-  /// Initializes iap features for both `Android` and `iOS`.
-  @Deprecated('Use initConnection() instead. Will be removed in version 7.0.0')
-  Future<String?> initialize() async {
-    if (_platform.isAndroid) {
-      await _setPurchaseListener();
-      return await _channel.invokeMethod('initConnection');
-    } else if (_platform.isIOS) {
-      await _setPurchaseListener();
-      final canMakePayments = await _channel.invokeMethod('canMakePayments');
-      return canMakePayments.toString();
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   Future<bool> isReady() async {
     if (_platform.isAndroid) {
@@ -783,34 +772,7 @@ class FlutterInappPurchase
     );
   }
 
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<bool> manageSubscription(String sku, String packageName) async {
-    if (_platform.isAndroid) {
-      return (await _channel.invokeMethod<bool?>(
-            'manageSubscription',
-            <String, dynamic>{'sku': sku, 'packageName': packageName},
-          )) ??
-          false;
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<bool> openPlayStoreSubscriptions() async {
-    if (_platform.isAndroid) {
-      return (await _channel.invokeMethod<bool?>(
-            'openPlayStoreSubscriptions',
-          )) ??
-          false;
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   Future<Store> getStore() async {
     if (_platform.isIOS) {
@@ -878,42 +840,10 @@ class FlutterInappPurchase
     );
   }
 
-  /// Retrieves the user's purchase history
-  Future<List<iap_types.PurchasedItem>?> getPurchaseHistory() async {
-    if (_platform.isAndroid) {
-      final dynamic getInappPurchaseHistory = await _channel.invokeMethod(
-        'getPurchaseHistoryByType',
-        <String, dynamic>{'type': TypeInApp.inapp.name},
-      );
+  /// Internal method to get available items from native platforms
+  Future<List<iap_types.Purchase>> _getAvailableItems() async {
+    final List<iap_types.PurchasedItem> items = [];
 
-      final dynamic getSubsPurchaseHistory = await _channel.invokeMethod(
-        'getPurchaseHistoryByType',
-        <String, dynamic>{'type': TypeInApp.subs.name},
-      );
-
-      return extractPurchased(getInappPurchaseHistory)! +
-          extractPurchased(getSubsPurchaseHistory)!;
-    } else if (_platform.isIOS) {
-      dynamic result = await _channel.invokeMethod('getAvailableItems');
-
-      return extractPurchased(json.encode(result));
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
-
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<String?> showInAppMessageAndroid() async {
-    if (!_platform.isAndroid) return Future.value('');
-    _onInAppMessageController ??= StreamController.broadcast();
-    return await _channel.invokeMethod('showInAppMessages');
-  }
-
-  /// Get all non-consumed purchases made
-  @override
-  Future<List<iap_types.PurchasedItem>?> getAvailableItemsIOS() async {
     if (_platform.isAndroid) {
       dynamic result1 = await _channel.invokeMethod(
         'getAvailableItemsByType',
@@ -924,47 +854,24 @@ class FlutterInappPurchase
         'getAvailableItemsByType',
         <String, dynamic>{'type': TypeInApp.subs.name},
       );
-      return extractPurchased(result1)! + extractPurchased(result2)!;
+      final consumables = extractPurchased(result1) ?? [];
+      final subscriptions = extractPurchased(result2) ?? [];
+      items.addAll(consumables);
+      items.addAll(subscriptions);
     } else if (_platform.isIOS) {
       dynamic result = await _channel.invokeMethod('getAvailableItems');
-
-      return extractPurchased(json.encode(result));
+      final iosItems = extractPurchased(json.encode(result)) ?? [];
+      items.addAll(iosItems);
+    } else {
+      throw PlatformException(
+        code: _platform.operatingSystem,
+        message: 'platform not supported',
+      );
     }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
+
+    return items.map((item) => _convertToPurchase(item)).toList();
   }
 
-  /// Request a purchase (old API)
-  Future<dynamic> _requestPurchaseOld(
-    String productId, {
-    String? obfuscatedAccountId,
-    String? purchaseTokenAndroid,
-    String? obfuscatedProfileIdAndroid,
-    int? offerTokenIndex,
-  }) async {
-    if (_platform.isAndroid) {
-      return await _channel.invokeMethod('buyItemByType', <String, dynamic>{
-        'type': TypeInApp.inapp.name,
-        'productId': productId,
-        'prorationMode': -1,
-        'obfuscatedAccountId': obfuscatedAccountId,
-        'obfuscatedProfileId': obfuscatedProfileIdAndroid,
-        'purchaseToken': purchaseTokenAndroid,
-        'offerTokenIndex': offerTokenIndex,
-      });
-    } else if (_platform.isIOS) {
-      return await _channel.invokeMethod('buyProduct', <String, dynamic>{
-        'sku': productId,
-        'forUser': obfuscatedAccountId,
-      });
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   /// Request a subscription
   Future<dynamic> requestSubscription(
@@ -996,69 +903,9 @@ class FlutterInappPurchase
     );
   }
 
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<String?> getPromotedProductIOS() async {
-    if (_platform.isIOS) {
-      return await _channel.invokeMethod('getPromotedProduct');
-    }
-    return null;
-  }
 
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<dynamic> requestPromotedProductIOS() async {
-    if (_platform.isIOS) {
-      return await _channel.invokeMethod('requestPromotedProduct');
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
-  @override
-  @Deprecated(
-    'Use requestPurchase() with RequestPurchase object. Will be removed in 6.0.0',
-  )
-  Future<dynamic> requestProductWithOfferIOS(
-    String sku,
-    String forUser,
-    Map<String, dynamic> withOffer,
-  ) async {
-    if (_platform.isIOS) {
-      return await _channel.invokeMethod(
-        'requestProductWithOfferIOS',
-        <String, dynamic>{
-          'sku': sku,
-          'forUser': forUser,
-          'withOffer': withOffer,
-        },
-      );
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
-  @override
-  @Deprecated(
-    'Use requestPurchase() with RequestPurchase object. Will be removed in 6.0.0',
-  )
-  Future<dynamic> requestPurchaseWithQuantityIOS(
-    String sku,
-    int quantity,
-  ) async {
-    if (_platform.isIOS) {
-      return await _channel.invokeMethod(
-        'requestProductWithQuantityIOS',
-        <String, dynamic>{'sku': sku, 'quantity': quantity.toString()},
-      );
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   Future<List<iap_types.PurchasedItem>?> getPendingTransactionsIOS() async {
     if (_platform.isIOS) {
@@ -1069,21 +916,6 @@ class FlutterInappPurchase
     return [];
   }
 
-  // Legacy method for backward compatibility
-  @Deprecated('Use finishTransaction() instead. Will be removed in 6.0.0')
-  Future<String?> consumePurchaseAndroidLegacy(String token) async {
-    if (_platform.isAndroid) {
-      return await _channel.invokeMethod('consumeProduct', <String, dynamic>{
-        'purchaseToken': token,
-      });
-    } else if (_platform.isIOS) {
-      return 'no-ops in ios';
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   @override
   Future<bool> consumePurchaseAndroid({required String purchaseToken}) async {
@@ -1171,19 +1003,6 @@ class FlutterInappPurchase
     );
   }
 
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<void> clearTransactionIOS() async {
-    if (_platform.isAndroid) {
-      return; // no-ops in android
-    } else if (_platform.isIOS) {
-      await _channel.invokeMethod('clearTransaction');
-      return;
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   Future<List<iap_types.IAPItem>> getAppStoreInitiatedProducts() async {
     if (_platform.isAndroid) {
@@ -1194,43 +1013,6 @@ class FlutterInappPurchase
       );
 
       return extractItems(json.encode(result));
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
-
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<bool> checkSubscribed({
-    required String sku,
-    Duration duration = const Duration(days: 30),
-    Duration grace = const Duration(days: 3),
-  }) async {
-    if (_platform.isIOS) {
-      var history = await getPurchaseHistory();
-
-      if (history == null) {
-        return false;
-      }
-
-      for (var purchase in history) {
-        Duration difference = DateTime.now().difference(
-          purchase.transactionDate!,
-        );
-        if (difference.inMinutes <= (duration + grace).inMinutes &&
-            purchase.productId == sku) return true;
-      }
-
-      return false;
-    } else if (_platform.isAndroid) {
-      var purchases = await (getAvailableItemsIOS());
-
-      for (var purchase in purchases ?? []) {
-        if (purchase.productId == sku) return true;
-      }
-
-      return false;
     }
     throw PlatformException(
       code: _platform.operatingSystem,
@@ -1256,22 +1038,6 @@ class FlutterInappPurchase
     );
   }
 
-  // Legacy method for backward compatibility
-  Future<http.Response> validateReceiptAndroidLegacy({
-    required String packageName,
-    required String productId,
-    required String productToken,
-    required String accessToken,
-    bool isSubscription = false,
-  }) async {
-    final String type = isSubscription ? 'subscriptions' : 'products';
-    final String url =
-        'https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken';
-    return await _client.get(
-      Uri.parse(url),
-      headers: {'Accept': 'application/json'},
-    );
-  }
 
   @override
   Future<Map<String, dynamic>?> validateReceiptAndroid({
@@ -1392,16 +1158,6 @@ class FlutterInappPurchase
     _purchaseErrorController = null;
   }
 
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<String> showPromoCodesIOS() async {
-    if (_platform.isIOS) {
-      return await _channel.invokeMethod<String>('showRedeemCodesIOS') ?? '';
-    }
-    throw PlatformException(
-      code: _platform.operatingSystem,
-      message: 'platform not supported',
-    );
-  }
 
   // flutter IAP compatible methods
 
@@ -1426,19 +1182,17 @@ class FlutterInappPurchase
         .toList();
   }
 
-  /// flutter IAP compatible method to get available purchases
-  Future<List<iap_types.Purchase>> getAvailablePurchasesAsync() async {
-    final items = await getAvailableItemsIOS();
-    return items?.map(_convertToPurchase).toList() ?? [];
-  }
-
   /// flutter IAP compatible purchase method
   Future<void> purchaseAsync(String productId) async {
     try {
       if (_platform.isIOS) {
         await _channel.invokeMethod('buyProduct', productId);
       } else if (_platform.isAndroid) {
-        await _requestPurchaseOld(productId);
+        await _channel.invokeMethod('buyItemByType', <String, dynamic>{
+          'type': TypeInApp.inapp.name,
+          'productId': productId,
+          'prorationMode': -1,
+        });
       }
     } catch (e) {
       throw iap_types.PurchaseError(
@@ -1480,7 +1234,7 @@ class FlutterInappPurchase
       await _channel.invokeMethod('restorePurchases');
     } else if (_platform.isAndroid) {
       // Android handles this automatically when querying purchases
-      await getAvailableItemsIOS();
+      await _getAvailableItems();
     }
   }
 

--- a/lib/modules/android.dart
+++ b/lib/modules/android.dart
@@ -11,7 +11,6 @@ import '../types.dart';
 mixin FlutterInappPurchaseAndroid {
   MethodChannel get channel;
   bool get _isAndroid;
-  String get _operatingSystem;
 
   /// Deep links to subscriptions screen on Android devices
   /// @param sku - The SKU of the subscription to deep link to
@@ -64,26 +63,6 @@ mixin FlutterInappPurchaseAndroid {
     }
   }
 
-  /// Acknowledges a purchase on Android (required within 3 days)
-  /// @param purchaseToken - The purchase token to acknowledge
-  @Deprecated('Use finishTransaction() instead. Will be removed in 6.0.0')
-  Future<bool> acknowledgePurchaseAndroid({
-    required String purchaseToken,
-  }) async {
-    if (!_isAndroid) {
-      return false;
-    }
-
-    try {
-      final result = await channel.invokeMethod<bool>('acknowledgePurchase', {
-        'purchaseToken': purchaseToken,
-      });
-      return result ?? false;
-    } catch (error) {
-      debugPrint('Error acknowledging purchase: $error');
-      return false;
-    }
-  }
 
   /// Consumes a purchase on Android (for consumable products)
   /// @param purchaseToken - The purchase token to consume
@@ -210,36 +189,7 @@ mixin FlutterInappPurchaseAndroid {
     }
   }
 
-  /// Manages a subscription on Android
-  @Deprecated('Not available in flutter IAP. Will be removed in 6.0.0')
-  Future<void> manageSubscriptionAndroid(String sku, String packageName) async {
-    if (!_isAndroid) {
-      throw PlatformException(
-        code: _operatingSystem,
-        message: 'manageSubscriptionAndroid is only supported on Android',
-      );
-    }
 
-    await channel.invokeMethod('manageSubscription', <String, dynamic>{
-      'sku': sku,
-      'packageName': packageName,
-    });
-  }
-
-  /// Acknowledges a purchase on Android (private method)
-  @Deprecated('Use finishTransaction() instead. Will be removed in 6.0.0')
-  Future<void> acknowledgePurchaseAndroidInternal(String purchaseToken) async {
-    if (!_isAndroid) {
-      throw PlatformException(
-        code: _operatingSystem,
-        message: '_acknowledgePurchaseAndroid is only supported on Android',
-      );
-    }
-
-    await channel.invokeMethod('acknowledgePurchase', <String, dynamic>{
-      'purchaseToken': purchaseToken,
-    });
-  }
 }
 
 /// In-app message model for Android

--- a/lib/modules/android.dart
+++ b/lib/modules/android.dart
@@ -63,7 +63,6 @@ mixin FlutterInappPurchaseAndroid {
     }
   }
 
-
   /// Consumes a purchase on Android (for consumable products)
   /// @param purchaseToken - The purchase token to consume
   Future<bool> consumePurchaseAndroid({required String purchaseToken}) async {
@@ -188,8 +187,6 @@ mixin FlutterInappPurchaseAndroid {
       return BillingClientState.disconnected;
     }
   }
-
-
 }
 
 /// In-app message model for Android

--- a/lib/modules/ios.dart
+++ b/lib/modules/ios.dart
@@ -82,8 +82,6 @@ mixin FlutterInappPurchaseIOS {
     }
   }
 
-
-
   /// Gets the iOS app store country code
   Future<String?> getAppStoreCountryIOS() async {
     if (!_isIOS) {

--- a/lib/modules/ios.dart
+++ b/lib/modules/ios.dart
@@ -82,46 +82,7 @@ mixin FlutterInappPurchaseIOS {
     }
   }
 
-  /// Requests a purchase with offer (iOS 12.2+)
-  @Deprecated(
-    'Use requestPurchase() with RequestPurchase object. Will be removed in 6.0.0',
-  )
-  Future<void> requestProductWithOfferIOS(
-    String sku,
-    String appAccountToken,
-    Map<String, dynamic> withOffer,
-  ) async {
-    if (!_isIOS) {
-      throw PlatformException(
-        code: _operatingSystem,
-        message: 'requestProductWithOfferIOS is only supported on iOS',
-      );
-    }
 
-    await channel.invokeMethod('requestProductWithOfferIOS', <String, dynamic>{
-      'sku': sku,
-      'appAccountToken': appAccountToken,
-      'withOffer': withOffer,
-    });
-  }
-
-  /// Requests a purchase with quantity (iOS)
-  @Deprecated(
-    'Use requestPurchase() with RequestPurchase object. Will be removed in 6.0.0',
-  )
-  Future<void> requestPurchaseWithQuantityIOS(String sku, int quantity) async {
-    if (!_isIOS) {
-      throw PlatformException(
-        code: _operatingSystem,
-        message: 'requestPurchaseWithQuantityIOS is only supported on iOS',
-      );
-    }
-
-    await channel.invokeMethod(
-      'requestPurchaseWithQuantityIOS',
-      <String, dynamic>{'sku': sku, 'quantity': quantity},
-    );
-  }
 
   /// Gets the iOS app store country code
   Future<String?> getAppStoreCountryIOS() async {

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -16,39 +16,6 @@ void main() {
     // Platform detection tests removed as getCurrentPlatform() uses Platform directly
     // and cannot be properly mocked in tests
 
-    group('showInAppMessageAndroid', () {
-      group('for Android', () {
-        final List<MethodCall> log = <MethodCall>[];
-        late FlutterInappPurchase testIap;
-        setUp(() {
-          testIap = FlutterInappPurchase.private(
-            FakePlatform(operatingSystem: 'android'),
-          );
-
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-            log.add(methodCall);
-            return 'ready';
-          });
-        });
-        test('invokes correct method', () async {
-          await testIap.showInAppMessageAndroid();
-          expect(log, <Matcher>[
-            isMethodCall('showInAppMessages', arguments: null),
-          ]);
-        });
-
-        tearDown(() {
-          channel.setMethodCallHandler(null);
-        });
-
-        test('returns correct result', () async {
-          final result = await testIap.showInAppMessageAndroid();
-          expect(result, 'ready');
-        });
-      });
-    });
-
     group('initConnection', () {
       group('for Android', () {
         final List<MethodCall> log = <MethodCall>[];
@@ -70,14 +37,15 @@ void main() {
         });
 
         test('invokes correct method', () async {
-          await testIap.initialize();
+          await testIap.initConnection();
           expect(log, <Matcher>[
             isMethodCall('initConnection', arguments: null),
           ]);
         });
 
         test('returns correct result', () async {
-          expect(await testIap.initialize(), 'Billing service is ready');
+          final result = await testIap.initConnection();
+          expect(result, true);
         });
       });
     });


### PR DESCRIPTION
## Changes
- Renamed `getAvailablePurchases()` to `getActivePurchases()` for clarity
- Renamed `getPurchaseHistory()` to `getPurchaseHistories()` for consistency
- Removed all deprecated methods marked for removal in v6.0.0
- Cleaned up legacy code and unused methods
- Updated example code to use new APIs

## Breaking Changes
- `getAvailablePurchases()` → `getActivePurchases()`
- Removed deprecated methods: `initialize()`, `checkSubscribed()`, `getAvailablePurchasesAsync()`, etc.

## Migration Guide
- Replace `getAvailablePurchases()` with `getActivePurchases()`
- Replace `getPurchaseHistory()` with `getPurchaseHistories()`
- Use `initConnection()` instead of `initialize()`
- Use `finishTransaction()` instead of deprecated platform-specific methods