### PR TITLE
fix: get subscription products types correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 6.3.1
+
+### Bug Fixes
+
+- **Android Subscription Loading**: Fixed type casting error when loading subscriptions
+  - Fixed `_Map<String, dynamic>` type casting issue that prevented subscriptions from loading
+  - Improved handling of pricing phases data structure from Android
+  - Fixed parsing of subscription offer details from nested JSON structure
+- **Test Product Cleanup**: Removed deprecated `android.test.purchased` test product ID
+  - This test ID is no longer valid in Google Play Billing Library 6+
+- **Type Safety**: Improved type handling for Map conversions from native platforms
+  - Better handling of different Map implementations from iOS and Android
+
 ## 6.3.0
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,18 @@ Before committing any changes, run these commands in order and ensure ALL pass:
 1. **Format check**: `dart format --set-exit-if-changed .`
    - This will fail if any files need formatting (exit code 1)
    - If it fails, run `dart format .` to fix formatting, then retry
-2. **Test validation**: `flutter test`
+   - Always format code before committing to maintain consistent style
+2. **Lint check**: `flutter analyze`
+   - Fix any lint issues before committing
+   - Pay attention to type inference errors and explicitly specify type arguments when needed
+3. **Test validation**: `flutter test`
    - All tests must pass
-3. **Final verification**: Re-run `dart format --set-exit-if-changed .` to confirm no formatting issues
-4. Only commit if ALL checks succeed with exit code 0
+4. **Final verification**: Re-run `dart format --set-exit-if-changed .` to confirm no formatting issues
+5. Only commit if ALL checks succeed with exit code 0
 
-**Important**: Use `--set-exit-if-changed` flag to match CI behavior and catch formatting issues locally before they cause CI failures.
+**Important**: 
+- Use `--set-exit-if-changed` flag to match CI behavior and catch formatting issues locally before they cause CI failures
+- When using generic functions like `showModalBottomSheet`, always specify explicit type arguments (e.g., `showModalBottomSheet<void>`) to avoid type inference errors
 
 ### Platform-Specific Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ dependencies:
 ## 🔄 What's New in 6.3.1
 
 ### Bug Fixes
+
 - Fixed Android subscription loading type casting error
 - Removed deprecated test product IDs
 - Improved type safety for native platform data

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@
 
 ```yaml
 dependencies:
-  flutter_inapp_purchase: ^6.3.0
+  flutter_inapp_purchase: ^6.3.1
 ```
+
+## 🔄 What's New in 6.3.1
+
+### Bug Fixes
+- Fixed Android subscription loading type casting error
+- Removed deprecated test product IDs
+- Improved type safety for native platform data
 
 ## 🔄 What's New in 6.3.0
 

--- a/android/src/main/kotlin/dev/hyo/flutterinapppurchase/AndroidInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/dev/hyo/flutterinapppurchase/AndroidInappPurchasePlugin.kt
@@ -500,31 +500,6 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
                             }
                         }
                         item.put("subscriptionOfferDetails", subsOffers)
-                        
-                        // Keep backward compatibility with subscriptionOffers
-                        val subs = JSONArray()
-                        if (productDetails.subscriptionOfferDetails != null ) {
-                            for (offer in productDetails.subscriptionOfferDetails!!) {
-                                val offerItem = JSONObject()
-                                offerItem.put("offerId", offer.offerId)
-                                offerItem.put("basePlanId", offer.basePlanId)
-                                offerItem.put("offerToken", offer.offerToken)
-                                val pricingPhasesArray = JSONArray()
-                                for (pricing in offer.pricingPhases.pricingPhaseList) {
-                                    val pricingPhase = JSONObject()
-                                    pricingPhase.put("price", (pricing.priceAmountMicros / 1000000f).toString())
-                                    pricingPhase.put("formattedPrice", pricing.formattedPrice)
-                                    pricingPhase.put("billingPeriod", pricing.billingPeriod)
-                                    pricingPhase.put("currencyCode", pricing.priceCurrencyCode)
-                                    pricingPhase.put("recurrenceMode", pricing.recurrenceMode)
-                                    pricingPhase.put("billingCycleCount", pricing.billingCycleCount)
-                                    pricingPhasesArray.put(pricingPhase)
-                                }
-                                offerItem.put("pricingPhases", pricingPhasesArray)
-                                subs.put(offerItem)
-                            }
-                        }
-                        item.put("subscriptionOffers", subs)
                     }
 
                     items.put(item)

--- a/android/src/main/kotlin/dev/hyo/flutterinapppurchase/AndroidInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/dev/hyo/flutterinapppurchase/AndroidInappPurchasePlugin.kt
@@ -590,9 +590,18 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
             }
 
             when (prorationMode) {
-                -1 -> {} //ignore
+                -1 -> {} //ignore - no proration mode specified
                 BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_PRORATED_PRICE -> {
-                    params.setOldPurchaseToken(purchaseToken ?: "")
+                    // For subscription replacement, purchaseToken is required
+                    if (purchaseToken.isNullOrEmpty()) {
+                        safeChannel.error(
+                            TAG,
+                            "buyItemByType",
+                            "Old SKU purchase information(token/id) or original external transaction id must be provided for subscription replacement."
+                        )
+                        return
+                    }
+                    params.setOldPurchaseToken(purchaseToken)
                         .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_PRORATED_PRICE)
                     builder.setSubscriptionUpdateParams(params.build())
                     if (type != BillingClient.ProductType.SUBS) {
@@ -605,29 +614,64 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
                     }
                 }
                 1 -> { // IMMEDIATE_WITHOUT_PRORATION
-                    params.setOldPurchaseToken(purchaseToken ?: "")
+                    if (purchaseToken.isNullOrEmpty()) {
+                        safeChannel.error(
+                            TAG,
+                            "buyItemByType",
+                            "Old SKU purchase information(token/id) or original external transaction id must be provided for subscription replacement."
+                        )
+                        return
+                    }
+                    params.setOldPurchaseToken(purchaseToken)
                         .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.WITHOUT_PRORATION)
                     builder.setSubscriptionUpdateParams(params.build())
                 }
                 4 -> { // DEFERRED
-                    params.setOldPurchaseToken(purchaseToken ?: "")
+                    if (purchaseToken.isNullOrEmpty()) {
+                        safeChannel.error(
+                            TAG,
+                            "buyItemByType",
+                            "Old SKU purchase information(token/id) or original external transaction id must be provided for deferred subscription replacement."
+                        )
+                        return
+                    }
+                    params.setOldPurchaseToken(purchaseToken)
                         .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.DEFERRED)
                     builder.setSubscriptionUpdateParams(params.build())
                 }
                 2 -> { // IMMEDIATE_WITH_TIME_PRORATION
-                    params.setOldPurchaseToken(purchaseToken ?: "")
+                    if (purchaseToken.isNullOrEmpty()) {
+                        safeChannel.error(
+                            TAG,
+                            "buyItemByType",
+                            "Old SKU purchase information(token/id) or original external transaction id must be provided for subscription replacement."
+                        )
+                        return
+                    }
+                    params.setOldPurchaseToken(purchaseToken)
                         .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.WITH_TIME_PRORATION)
                     builder.setSubscriptionUpdateParams(params.build())
                 }
                 5 -> { // IMMEDIATE_AND_CHARGE_FULL_PRICE
-                    params.setOldPurchaseToken(purchaseToken ?: "")
+                    if (purchaseToken.isNullOrEmpty()) {
+                        safeChannel.error(
+                            TAG,
+                            "buyItemByType",
+                            "Old SKU purchase information(token/id) or original external transaction id must be provided for subscription replacement."
+                        )
+                        return
+                    }
+                    params.setOldPurchaseToken(purchaseToken)
                         .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.CHARGE_FULL_PRICE)
                     builder.setSubscriptionUpdateParams(params.build())
                 }
                 else -> {
-                    params.setOldPurchaseToken(purchaseToken ?: "")
-                        .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.UNKNOWN_REPLACEMENT_MODE)
-                    builder.setSubscriptionUpdateParams(params.build())
+                    // For any other proration mode, also require purchase token
+                    if (!purchaseToken.isNullOrEmpty()) {
+                        params.setOldPurchaseToken(purchaseToken)
+                            .setSubscriptionReplacementMode(BillingFlowParams.SubscriptionUpdateParams.ReplacementMode.UNKNOWN_REPLACEMENT_MODE)
+                        builder.setSubscriptionUpdateParams(params.build())
+                    }
                 }
             }
             if (activity != null) {

--- a/docs/docs/guides/ios-purchase-state-detection.md
+++ b/docs/docs/guides/ios-purchase-state-detection.md
@@ -1,0 +1,194 @@
+# iOS Purchase State Detection
+
+## Overview
+
+iOS purchase state detection can be complex due to the differences in how iOS App Store handles purchase confirmations compared to Android Google Play Store. This guide explains the common issues and solutions for proper iOS purchase state detection in flutter_inapp_purchase.
+
+## Common iOS Purchase Issues
+
+### 1. Processing State Stuck Issue
+
+**Problem**: iOS purchases succeed (valid tokens and transaction IDs are generated) but the UI remains stuck in "Processing..." state.
+
+**Root Cause**: The `transactionStateIOS` field often returns `null` even for successful purchases, while `purchaseToken` and `transactionId` contain valid data.
+
+**Solution**: Use multiple conditions to detect successful purchases:
+
+```dart
+bool isPurchased = false;
+
+if (Platform.isIOS) {
+  bool condition1 = purchase.transactionStateIOS == TransactionState.purchased;
+  bool condition2 = purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpty;
+  bool condition3 = purchase.transactionId != null && purchase.transactionId!.isNotEmpty;
+
+  // For iOS, receiving a purchase update usually means success
+  // especially if we have either a valid token OR transaction ID
+  isPurchased = condition1 || condition2 || condition3;
+}
+```
+
+### 2. Timeout Errors
+
+**Problem**: iOS purchases fail with timeout errors ("요청한 시간이 초과되었습니다").
+
+**Root Cause**: Apple App Store server issues or network connectivity problems.
+
+**Solutions**:
+- Wait a few minutes and retry
+- Check network connection (try switching between WiFi and cellular)
+- Test on real device instead of simulator
+- Restart the app or device
+- Check Apple system status
+
+## Implementation Best Practices
+
+### 1. Comprehensive Purchase State Detection
+
+```dart
+Future<void> _handlePurchaseUpdate(Purchase purchase) async {
+  print('🎯 Purchase update received: ${purchase.productId}');
+  print('  Platform: ${purchase.platform}');
+  print('  Transaction state iOS: ${purchase.transactionStateIOS}');
+  print('  Purchase token: ${purchase.purchaseToken}');
+  print('  Transaction ID: ${purchase.transactionId}');
+
+  bool isPurchased = false;
+
+  if (Platform.isIOS) {
+    // Enhanced iOS detection logic
+    bool hasValidState = purchase.transactionStateIOS == TransactionState.purchased;
+    bool hasValidToken = purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpty;
+    bool hasValidTransactionId = purchase.transactionId != null && purchase.transactionId!.isNotEmpty;
+
+    isPurchased = hasValidState || hasValidToken || hasValidTransactionId;
+    
+    print('  iOS condition checks:');
+    print('    transactionStateIOS == purchased: $hasValidState');
+    print('    has valid purchaseToken: $hasValidToken');
+    print('    has valid transactionId: $hasValidTransactionId');
+    print('  Final isPurchased: $isPurchased');
+  }
+
+  if (isPurchased) {
+    // Handle successful purchase
+    setState(() {
+      _isProcessing = false;
+      _purchaseResult = '✅ Purchase successful: ${purchase.productId}';
+    });
+
+    // Finish the transaction
+    await _iap.finishTransaction(purchase);
+  }
+}
+```
+
+### 2. Timeout Error Handling
+
+```dart
+void _handlePurchaseError(PurchaseError error) {
+  if (error.message.contains('요청한 시간이 초과되었습니다') || 
+      error.message.contains('timeout') ||
+      error.message.contains('timed out')) {
+    // Handle timeout specifically
+    setState(() {
+      _purchaseResult = '''
+⏱️ Request Timeout
+Code: ${error.code}
+Message: ${error.message}
+
+🔄 Suggested Actions:
+1. Check your internet connection
+2. Wait a few minutes and try again
+3. Restart the app
+4. Try on a different network (WiFi/Cellular)
+5. Restart your device
+6. Check Apple server status
+
+This is usually a temporary server issue.
+      ''';
+    });
+  }
+}
+```
+
+### 3. Duplicate Transaction Prevention
+
+```dart
+class _PurchaseScreenState extends State<PurchaseScreen> {
+  final Set<String> _processedTransactionIds = {};
+
+  Future<void> _handlePurchaseUpdate(Purchase purchase) async {
+    // Check for duplicate processing
+    final transactionId = purchase.transactionId ?? purchase.purchaseToken ?? '';
+    if (transactionId.isNotEmpty && _processedTransactionIds.contains(transactionId)) {
+      print('⚠️ Transaction already processed: $transactionId');
+      return;
+    }
+
+    // Process purchase...
+    
+    // Mark as processed
+    if (transactionId.isNotEmpty) {
+      _processedTransactionIds.add(transactionId);
+    }
+  }
+}
+```
+
+## Debugging iOS Purchase Issues
+
+### 1. Enable Detailed Logging
+
+Add comprehensive logging to understand what's happening:
+
+```dart
+print('🎯 Purchase updated: ${purchase.productId}');
+print('  Platform: ${purchase.platform}');
+print('  Purchase state: ${purchase.purchaseState}');
+print('  Transaction state iOS: ${purchase.transactionStateIOS}');
+print('  Transaction ID: ${purchase.transactionId}');
+print('  Purchase token: ${purchase.purchaseToken}');
+print('  Purchase token length: ${purchase.purchaseToken?.length ?? 0}');
+```
+
+### 2. Test on Real Device
+
+iOS Simulator can have different behavior than real devices. Always test critical purchase flows on physical iOS devices.
+
+### 3. Check StoreKit Configuration
+
+Ensure your StoreKit configuration file (if using StoreKit testing) has the correct product IDs and is properly configured.
+
+## Troubleshooting Checklist
+
+### For Processing State Issues:
+- [ ] Verify purchase update listener is properly set up
+- [ ] Check if `purchaseToken` or `transactionId` are present even when `transactionStateIOS` is null
+- [ ] Ensure UI state is updated in the purchase listener
+- [ ] Verify transaction is being finished with `finishTransaction()`
+
+### For Timeout Issues:
+- [ ] Test on different network connections
+- [ ] Try on real device vs simulator
+- [ ] Check Apple system status
+- [ ] Verify product IDs are correct
+- [ ] Ensure App Store Connect configuration is complete
+
+### For Double Purchase Issues:
+- [ ] Implement transaction ID tracking
+- [ ] Check for duplicate listeners
+- [ ] Verify `finishTransaction()` is called properly
+- [ ] Add proper error handling
+
+## Related Issues
+
+- [iOS purchases stuck in Processing state](https://github.com/hyochan/flutter_inapp_purchase/issues/XXX)
+- [Apple timeout errors](https://github.com/hyochan/flutter_inapp_purchase/issues/XXX)
+- [Transaction state detection improvements](https://github.com/hyochan/flutter_inapp_purchase/issues/XXX)
+
+## See Also
+
+- [Purchase Flow Implementation](../examples/basic-store.md)
+- [Error Handling Guide](./error-handling.md)
+- [Troubleshooting Guide](./troubleshooting.md)

--- a/example/lib/src/screens/purchase_flow_screen.dart
+++ b/example/lib/src/screens/purchase_flow_screen.dart
@@ -143,22 +143,22 @@ class _PurchaseFlowScreenState extends State<PurchaseFlowScreen> {
           purchase.purchaseToken != null &&
           purchase.purchaseToken!.isNotEmpty);
       bool condition3 = purchase.purchaseStateAndroid == 1;
-      
+
       print('  Android condition checks:');
       print('    purchaseState == purchased: $condition1');
       print('    unacknowledged with token: $condition2');
       print('    purchaseStateAndroid == 1: $condition3');
-      
+
       isPurchased = condition1 || condition2 || condition3;
       print('  Final isPurchased: $isPurchased');
     } else {
       // For iOS - same logic as subscription flow
       bool condition1 =
           purchase.transactionStateIOS == TransactionState.purchased;
-      bool condition2 = purchase.purchaseToken != null &&
-          purchase.purchaseToken!.isNotEmpty;
-      bool condition3 = purchase.transactionId != null &&
-          purchase.transactionId!.isNotEmpty;
+      bool condition2 =
+          purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpty;
+      bool condition3 =
+          purchase.transactionId != null && purchase.transactionId!.isNotEmpty;
 
       print('  iOS condition checks:');
       print('    transactionStateIOS == purchased: $condition1');
@@ -181,7 +181,8 @@ Purchase state: ${purchase.purchaseState}
 iOS transaction state: ${purchase.transactionStateIOS}
 Android purchase state: ${purchase.purchaseStateAndroid}
 Has token: ${purchase.purchaseToken != null && purchase.purchaseToken!.isNotEmpty}
-        '''.trim();
+        '''
+            .trim();
       });
       return;
     }
@@ -249,9 +250,9 @@ Purchase Token: ${purchase.purchaseToken?.substring(0, 30)}...
       // Format error result like KMP-IAP
       if (error.code == ErrorCode.eUserCancelled) {
         _purchaseResult = '⚠️ Purchase cancelled by user';
-      } else if (error.message.contains('요청한 시간이 초과되었습니다') || 
-                 error.message.contains('timeout') ||
-                 error.message.contains('timed out')) {
+      } else if (error.message.contains('요청한 시간이 초과되었습니다') ||
+          error.message.contains('timeout') ||
+          error.message.contains('timed out')) {
         // Apple/Google server timeout error
         _purchaseResult = '''
 ⏱️ Request Timeout

--- a/example/lib/src/widgets/product_detail_modal.dart
+++ b/example/lib/src/widgets/product_detail_modal.dart
@@ -1,0 +1,326 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+
+class ProductDetailModal extends StatelessWidget {
+  final IAPItem item;
+  final BaseProduct? product;
+
+  const ProductDetailModal({
+    Key? key,
+    required this.item,
+    this.product,
+  }) : super(key: key);
+
+  static void show({
+    required BuildContext context,
+    required IAPItem item,
+    BaseProduct? product,
+  }) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => ProductDetailModal(
+        item: item,
+        product: product,
+      ),
+    );
+  }
+
+  Map<String, dynamic> _itemToMap(IAPItem item) {
+    final map = <String, dynamic>{
+      'productId': item.productId,
+      'price': item.price,
+      'currency': item.currency,
+      'localizedPrice': item.localizedPrice,
+      'title': item.title,
+      'description': item.description,
+      'introductoryPrice': item.introductoryPrice,
+      'subscriptionPeriodNumberIOS': item.subscriptionPeriodNumberIOS,
+      'subscriptionPeriodUnitIOS': item.subscriptionPeriodUnitIOS,
+      'introductoryPriceNumberOfPeriodsIOS':
+          item.introductoryPriceNumberOfPeriodsIOS,
+      'introductoryPriceSubscriptionPeriodIOS':
+          item.introductoryPriceSubscriptionPeriodIOS,
+      'discountsIOS': item.discountsIOS
+          ?.map((d) => {
+                'identifier': d.identifier,
+                'type': d.type,
+                'numberOfPeriods': d.numberOfPeriods,
+                'price': d.price,
+                'localizedPrice': d.localizedPrice,
+                'paymentMode': d.paymentMode,
+                'subscriptionPeriod': d.subscriptionPeriod,
+              })
+          .toList(),
+      'subscriptionPeriodAndroid': item.subscriptionPeriodAndroid,
+      'signatureAndroid': item.signatureAndroid,
+      'iconUrl': item.iconUrl,
+      'originalJson': item.originalJson,
+      'originalPrice': item.originalPrice,
+      'subscriptionOffersAndroid': item.subscriptionOffersAndroid
+          ?.map((o) => {
+                'sku': o.sku,
+                'offerToken': o.offerToken,
+              })
+          .toList(),
+    };
+
+    // Remove null values for cleaner display
+    map.removeWhere((key, value) => value == null);
+
+    return map;
+  }
+
+  Widget _buildSection(String title, Widget content) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: Text(
+            title,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ),
+        content,
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _buildDetailRow(String label, String? value) {
+    if (value == null || value.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 140,
+            child: Text(
+              '$label:',
+              style: const TextStyle(
+                fontWeight: FontWeight.w500,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontWeight: FontWeight.w400),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final jsonString =
+        const JsonEncoder.withIndent('  ').convert(_itemToMap(item));
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) => Container(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          children: [
+            Container(
+              margin: const EdgeInsets.symmetric(vertical: 8),
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      item.title ?? item.productId ?? 'Product Details',
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView(
+                controller: scrollController,
+                padding: const EdgeInsets.all(16),
+                children: [
+                  // Basic Information
+                  _buildSection(
+                    'Basic Information',
+                    Column(
+                      children: [
+                        _buildDetailRow('Product ID', item.productId),
+                        _buildDetailRow('Price', item.localizedPrice),
+                        _buildDetailRow('Currency', item.currency),
+                        if (item.originalPrice != null)
+                          _buildDetailRow(
+                              'Original Price', item.originalPrice.toString()),
+                        _buildDetailRow('Description', item.description),
+                      ],
+                    ),
+                  ),
+
+                  // Subscription Information (if applicable)
+                  if (item.subscriptionPeriodAndroid != null ||
+                      item.subscriptionPeriodUnitIOS != null)
+                    _buildSection(
+                      'Subscription Details',
+                      Column(
+                        children: [
+                          if (item.subscriptionPeriodAndroid != null)
+                            _buildDetailRow('Period (Android)',
+                                item.subscriptionPeriodAndroid),
+                          if (item.subscriptionPeriodUnitIOS != null)
+                            _buildDetailRow(
+                              'Period (iOS)',
+                              '${item.subscriptionPeriodNumberIOS ?? ''} ${item.subscriptionPeriodUnitIOS}',
+                            ),
+                          if (item.introductoryPrice != null)
+                            _buildDetailRow(
+                                'Introductory Price', item.introductoryPrice),
+                        ],
+                      ),
+                    ),
+
+                  // Android Offers
+                  if (item.subscriptionOffersAndroid?.isNotEmpty ?? false)
+                    _buildSection(
+                      'Android Subscription Offers',
+                      Column(
+                        children: item.subscriptionOffersAndroid!
+                            .map((offer) => Card(
+                                  margin:
+                                      const EdgeInsets.symmetric(vertical: 4),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(12),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        _buildDetailRow('SKU', offer.sku),
+                                        _buildDetailRow(
+                                          'Token',
+                                          offer.offerToken.length > 20
+                                              ? '${offer.offerToken.substring(0, 20)}...'
+                                              : offer.offerToken,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ))
+                            .toList(),
+                      ),
+                    ),
+
+                  // iOS Discounts
+                  if (item.discountsIOS?.isNotEmpty ?? false)
+                    _buildSection(
+                      'iOS Discounts',
+                      Column(
+                        children: item.discountsIOS!
+                            .map((discount) => Card(
+                                  margin:
+                                      const EdgeInsets.symmetric(vertical: 4),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(12),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        _buildDetailRow(
+                                            'Identifier', discount.identifier),
+                                        _buildDetailRow(
+                                            'Price', discount.localizedPrice),
+                                        _buildDetailRow('Type', discount.type),
+                                        _buildDetailRow('Payment Mode',
+                                            discount.paymentMode),
+                                      ],
+                                    ),
+                                  ),
+                                ))
+                            .toList(),
+                      ),
+                    ),
+
+                  // Raw JSON Data
+                  _buildSection(
+                    'Raw Data (JSON)',
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.grey[100],
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(color: Colors.grey[300]!),
+                      ),
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: SelectableText(
+                          jsonString,
+                          style: const TextStyle(
+                            fontFamily: 'monospace',
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  // Original Product Data (if available)
+                  if (product != null)
+                    _buildSection(
+                      'Original Product Object',
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Colors.blue[50],
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Colors.blue[200]!),
+                        ),
+                        child: Text(
+                          product.toString(),
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/enums.dart
+++ b/lib/enums.dart
@@ -135,6 +135,32 @@ enum ResponseCodeAndroid {
 enum PurchaseState { pending, purchased, unspecified }
 
 /// Android Proration Mode
+///
+/// IMPORTANT: Proration modes are ONLY for upgrading/downgrading EXISTING subscriptions.
+/// For NEW subscriptions, do NOT use any proration mode.
+///
+/// To use proration mode:
+/// 1. User must have an active subscription
+/// 2. You must provide the purchaseToken from the existing subscription
+/// 3. Get the token using getAvailablePurchases()
+///
+/// Example:
+/// ```dart
+/// // First, check for existing subscription
+/// final purchases = await FlutterInappPurchase.instance.getAvailablePurchases();
+/// if (purchases.isEmpty) {
+///   // User has no subscription - purchase new one WITHOUT proration mode
+///   await FlutterInappPurchase.instance.requestSubscription('premium_monthly');
+/// } else {
+///   // User has subscription - can upgrade/downgrade WITH proration mode
+///   final existingSub = purchases.first;
+///   await FlutterInappPurchase.instance.requestSubscription(
+///     'premium_yearly',
+///     prorationModeAndroid: AndroidProrationMode.immediateWithTimeProration.value,
+///     purchaseTokenAndroid: existingSub.purchaseToken,
+///   );
+/// }
+/// ```
 enum AndroidProrationMode {
   unknownSubscriptionUpgradeDowngradePolicy(0),
   immediateWithTimeProration(1),

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -1216,12 +1216,18 @@ class FlutterInappPurchase
         return;
       } else {
         if (purchase.isAcknowledgedAndroid == true) {
-          print(
-              '[FlutterInappPurchase] Android: Purchase already acknowledged');
+          if (kDebugMode) {
+            debugPrint(
+                '[FlutterInappPurchase] Android: Purchase already acknowledged');
+          }
           return;
         } else {
-          print(
-              '[FlutterInappPurchase] Android: Acknowledging purchase with token: ${purchase.purchaseToken}');
+          if (kDebugMode) {
+            final maskedToken = (purchase.purchaseToken ?? '')
+                .replaceAllMapped(RegExp(r'.(?=.{4})'), (m) => '*');
+            debugPrint(
+                '[FlutterInappPurchase] Android: Acknowledging purchase with token: $maskedToken');
+          }
           await _channel.invokeMethod('acknowledgePurchase', <String, dynamic>{
             'purchaseToken': purchase.purchaseToken,
           });

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -207,30 +207,44 @@ class FlutterInappPurchase
       } else if (params.type == iap_types.PurchaseType.inapp) {
         rawResult = await _channel.invokeMethod(
           'getProducts',
-          params.productIds,
+          {'productIds': params.productIds},
         );
       } else {
         rawResult = await _channel.invokeMethod(
           'getSubscriptions',
-          params.productIds,
+          {'productIds': params.productIds},
         );
       }
 
-      final List<dynamic> result = rawResult as List<dynamic>? ?? [];
+      // Android returns JSON string, iOS returns List
+      final List<dynamic> result;
+      if (rawResult is String) {
+        // Parse JSON string from Android
+        result = jsonDecode(rawResult) as List<dynamic>? ?? [];
+      } else {
+        result = rawResult as List<dynamic>? ?? [];
+      }
 
       print(
         '[flutter_inapp_purchase] Received ${result.length} items from native',
       );
 
       // Convert directly to Product/Subscription without intermediate IAPItem
-      return result
-          .map(
-            (item) => _parseProductFromNative(
-              Map<String, dynamic>.from(item as Map),
-              params.type,
-            ),
-          )
-          .toList();
+      return result.map(
+        (item) {
+          // Handle different Map types from iOS and Android
+          final Map<String, dynamic> itemMap;
+          if (item is Map<String, dynamic>) {
+            itemMap = item;
+          } else if (item is Map) {
+            // Convert Map<Object?, Object?> to Map<String, dynamic>
+            itemMap = Map<String, dynamic>.from(item);
+          } else {
+            throw Exception('Unexpected item type: ${item.runtimeType}');
+          }
+          return _parseProductFromNative(itemMap, params.type);
+        },
+      ).toList();
     } catch (e) {
       throw iap_types.PurchaseError(
         code: iap_types.ErrorCode.eServiceError,
@@ -650,7 +664,7 @@ class FlutterInappPurchase
         discountsIOS: _parseDiscountsIOS(json['discounts']),
         subscription: json['subscription'] != null
             ? iap_types.SubscriptionInfo.fromJson(
-                json['subscription'] as Map<String, dynamic>)
+                Map<String, dynamic>.from(json['subscription'] as Map))
             : json['subscriptionGroupId'] != null
                 ? iap_types.SubscriptionInfo(
                     subscriptionGroupId: json['subscriptionGroupId'] as String?,
@@ -699,13 +713,32 @@ class FlutterInappPurchase
     if (json == null) return null;
     final list = json as List<dynamic>;
     return list
-        .map((e) => iap_types.DiscountIOS.fromJson(e as Map<String, dynamic>))
+        .map((e) => iap_types.DiscountIOS.fromJson(e is Map<String, dynamic>
+            ? e
+            : Map<String, dynamic>.from(e as Map)))
         .toList();
   }
 
   List<iap_types.OfferDetail>? _parseOfferDetails(dynamic json) {
     if (json == null) return null;
-    final list = json as List<dynamic>;
+
+    // Handle both List and String (JSON string from Android)
+    List<dynamic> list;
+    if (json is String) {
+      // Parse JSON string from Android
+      try {
+        final parsed = jsonDecode(json);
+        if (parsed is! List) return null;
+        list = parsed;
+      } catch (e) {
+        return null;
+      }
+    } else if (json is List) {
+      list = json;
+    } else {
+      return null;
+    }
+
     return list
         .map(
           (e) => iap_types.OfferDetail(
@@ -721,18 +754,41 @@ class FlutterInappPurchase
 
   List<iap_types.PricingPhase>? _parsePricingPhases(dynamic json) {
     if (json == null) return null;
-    final list = json as List<dynamic>;
-    return list
-        .map(
-          (e) => iap_types.PricingPhase(
-            priceAmount: (e['priceAmountMicros'] as num?)?.toDouble() ?? 0.0,
-            price: e['formattedPrice'] as String? ?? '0',
-            currency: e['priceCurrencyCode'] as String? ?? 'USD',
-            billingPeriod: e['billingPeriod'] as String?,
-            billingCycleCount: e['billingCycleCount'] as int?,
-          ),
-        )
-        .toList();
+
+    // Handle nested structure from Android
+    List<dynamic>? list;
+    if (json is Map && json['pricingPhaseList'] != null) {
+      list = json['pricingPhaseList'] as List<dynamic>?;
+    } else if (json is List) {
+      list = json;
+    } else {
+      return null;
+    }
+
+    if (list == null) return null;
+
+    return list.map(
+      (e) {
+        // Handle priceAmountMicros as either String or num
+        final priceAmountMicros = e['priceAmountMicros'];
+        double priceAmount = 0.0;
+        if (priceAmountMicros != null) {
+          if (priceAmountMicros is String) {
+            priceAmount = double.tryParse(priceAmountMicros) ?? 0.0;
+          } else if (priceAmountMicros is num) {
+            priceAmount = priceAmountMicros.toDouble();
+          }
+        }
+
+        return iap_types.PricingPhase(
+          priceAmount: priceAmount,
+          price: e['formattedPrice'] as String? ?? '0',
+          currency: e['priceCurrencyCode'] as String? ?? 'USD',
+          billingPeriod: e['billingPeriod'] as String?,
+          billingCycleCount: e['billingCycleCount'] as int?,
+        );
+      },
+    ).toList();
   }
 
   iap_types.PurchaseState _mapAndroidPurchaseState(int state) {

--- a/lib/types.dart
+++ b/lib/types.dart
@@ -179,7 +179,7 @@ class Product extends BaseProduct {
           : null,
       subscription: json['subscription'] != null
           ? SubscriptionInfo.fromJson(
-              json['subscription'] as Map<String, dynamic>,
+              Map<String, dynamic>.from(json['subscription'] as Map),
             )
           : null,
       introductoryPriceNumberOfPeriodsIOS:
@@ -411,7 +411,7 @@ class Subscription extends BaseProduct {
           : null,
       subscription: json['subscription'] != null
           ? SubscriptionInfo.fromJson(
-              json['subscription'] as Map<String, dynamic>,
+              Map<String, dynamic>.from(json['subscription'] as Map),
             )
           : null,
       introductoryPriceNumberOfPeriodsIOS:
@@ -645,8 +645,12 @@ class SubscriptionInfo {
   factory SubscriptionInfo.fromJson(Map<String, dynamic> json) {
     return SubscriptionInfo(
       subscriptionGroupId: json['subscriptionGroupId'] as String?,
-      subscriptionPeriod: json['subscriptionPeriod'] as Map<String, dynamic>?,
-      introductoryOffer: json['introductoryOffer'] as Map<String, dynamic>?,
+      subscriptionPeriod: json['subscriptionPeriod'] != null
+          ? Map<String, dynamic>.from(json['subscriptionPeriod'] as Map)
+          : null,
+      introductoryOffer: json['introductoryOffer'] != null
+          ? Map<String, dynamic>.from(json['introductoryOffer'] as Map)
+          : null,
       promotionalOffers: json['promotionalOffers'] as List<dynamic>?,
       introductoryPrice: json['introductoryPrice'] as String?,
     );
@@ -997,7 +1001,9 @@ class Purchase {
       ownershipTypeIOS: json['ownershipTypeIOS'] as String?,
       transactionReasonIOS: json['transactionReasonIOS'] as String?,
       reasonIOS: json['reasonIOS'] as String?,
-      offerIOS: json['offerIOS'] as Map<String, dynamic>?,
+      offerIOS: json['offerIOS'] != null
+          ? Map<String, dynamic>.from(json['offerIOS'] as Map)
+          : null,
       jwsRepresentationIOS: json['jwsRepresentationIOS'] as String?,
       // Android specific per OpenIAP spec
       signatureAndroid: json['signatureAndroid'] as String?,
@@ -1642,8 +1648,12 @@ class ValidationResult {
     return ValidationResult(
       isValid: json['isValid'] as bool? ?? false,
       errorMessage: json['errorMessage'] as String?,
-      receipt: json['receipt'] as Map<String, dynamic>?,
-      parsedReceipt: json['parsedReceipt'] as Map<String, dynamic>?,
+      receipt: json['receipt'] != null
+          ? Map<String, dynamic>.from(json['receipt'] as Map)
+          : null,
+      parsedReceipt: json['parsedReceipt'] != null
+          ? Map<String, dynamic>.from(json['parsedReceipt'] as Map)
+          : null,
       originalResponse: json['originalResponse'] as String?,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_inapp_purchase
 description: In App Purchase plugin for flutter. This project has been forked by
   react-native-iap and we are willing to share same experience with that on
   react-native.
-version: 6.3.0
+version: 6.3.1
 homepage: https://github.com/hyochan/flutter_inapp_purchase/blob/main/pubspec.yaml
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/proration_mode_validation_test.dart
+++ b/test/proration_mode_validation_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Proration Mode Validation Tests', () {
+    test(
+        'requestSubscription throws error when using deferred proration without purchaseToken',
+        () {
+      // Test that using deferred proration mode without purchaseToken throws an error
+      expect(
+        () => RequestSubscriptionAndroid(
+          skus: ['test_subscription'],
+          replacementModeAndroid: 4, // DEFERRED mode
+          subscriptionOffers: [],
+          // Missing purchaseTokenAndroid - should trigger assert in debug mode
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('requestSubscription allows deferred proration with purchaseToken',
+        () {
+      // Test that using deferred proration mode with purchaseToken works
+      final request = RequestSubscriptionAndroid(
+        skus: ['test_subscription'],
+        replacementModeAndroid: 4, // DEFERRED mode
+        purchaseTokenAndroid: 'valid_purchase_token',
+        subscriptionOffers: [],
+      );
+
+      expect(request.skus, ['test_subscription']);
+      expect(request.replacementModeAndroid, 4);
+      expect(request.purchaseTokenAndroid, 'valid_purchase_token');
+    });
+
+    test('requestSubscription works without proration mode', () {
+      // Test that normal subscription request without proration works
+      final request = RequestSubscriptionAndroid(
+        skus: ['test_subscription'],
+        subscriptionOffers: [],
+      );
+
+      expect(request.skus, ['test_subscription']);
+      expect(request.replacementModeAndroid, null);
+      expect(request.purchaseTokenAndroid, null);
+    });
+
+    test('requestSubscription works with proration mode -1 (default)', () {
+      // Test that using default value (-1) doesn't require purchaseToken
+      final request = RequestSubscriptionAndroid(
+        skus: ['test_subscription'],
+        replacementModeAndroid: -1,
+        subscriptionOffers: [],
+      );
+
+      expect(request.skus, ['test_subscription']);
+      expect(request.replacementModeAndroid, -1);
+    });
+
+    test(
+        'requestSubscription throws for all proration modes without purchaseToken',
+        () {
+      // Test all Android proration modes that require purchaseToken
+      final prorationModes = [
+        1, // IMMEDIATE_WITH_TIME_PRORATION
+        2, // IMMEDIATE_WITHOUT_PRORATION
+        3, // IMMEDIATE_AND_CHARGE_PRORATED_PRICE
+        4, // DEFERRED
+        5, // IMMEDIATE_AND_CHARGE_FULL_PRICE
+      ];
+
+      for (final mode in prorationModes) {
+        expect(
+          () => RequestSubscriptionAndroid(
+            skus: ['test_subscription'],
+            replacementModeAndroid: mode,
+            subscriptionOffers: [],
+            // Missing purchaseTokenAndroid
+          ),
+          throwsAssertionError,
+          reason: 'Proration mode $mode should require purchaseToken',
+        );
+      }
+    });
+
+    test('requestSubscription works for all proration modes with purchaseToken',
+        () {
+      // Test all Android proration modes work with purchaseToken
+      final prorationModes = [
+        1, // IMMEDIATE_WITH_TIME_PRORATION
+        2, // IMMEDIATE_WITHOUT_PRORATION
+        3, // IMMEDIATE_AND_CHARGE_PRORATED_PRICE
+        4, // DEFERRED
+        5, // IMMEDIATE_AND_CHARGE_FULL_PRICE
+      ];
+
+      for (final mode in prorationModes) {
+        final request = RequestSubscriptionAndroid(
+          skus: ['test_subscription'],
+          replacementModeAndroid: mode,
+          purchaseTokenAndroid: 'valid_token',
+          subscriptionOffers: [],
+        );
+
+        expect(request.replacementModeAndroid, mode);
+        expect(request.purchaseTokenAndroid, 'valid_token');
+      }
+    });
+  });
+}

--- a/test/purchase_flow_test.dart
+++ b/test/purchase_flow_test.dart
@@ -25,7 +25,11 @@ void main() {
             case 'getProducts':
             case 'getSubscriptions':
               final args = methodCall.arguments;
-              final productIds = args is List ? args.cast<String>() : null;
+              final productIds = args is Map 
+                  ? (args['productIds'] as List?)?.cast<String>()
+                  : args is List 
+                      ? args.cast<String>() 
+                      : null;
               final allProducts = _getMockProducts();
               final filteredProducts = productIds != null
                   ? allProducts

--- a/test/purchase_flow_test.dart
+++ b/test/purchase_flow_test.dart
@@ -25,10 +25,10 @@ void main() {
             case 'getProducts':
             case 'getSubscriptions':
               final args = methodCall.arguments;
-              final productIds = args is Map 
+              final productIds = args is Map
                   ? (args['productIds'] as List?)?.cast<String>()
-                  : args is List 
-                      ? args.cast<String>() 
+                  : args is List
+                      ? args.cast<String>()
                       : null;
               final allProducts = _getMockProducts();
               final filteredProducts = productIds != null

--- a/test/purchase_flow_test.dart
+++ b/test/purchase_flow_test.dart
@@ -26,9 +26,11 @@ void main() {
             case 'getSubscriptions':
               final args = methodCall.arguments;
               final productIds = args is Map
-                  ? (args['productIds'] as List?)?.cast<String>()
-                  : args is List
-                      ? args.cast<String>()
+                  ? (args['productIds'] as Iterable?)
+                      ?.map((e) => e.toString())
+                      .toList()
+                  : args is Iterable
+                      ? args.map((e) => e.toString()).toList()
                       : null;
               final allProducts = _getMockProducts();
               final filteredProducts = productIds != null

--- a/test/subscription_flow_test.dart
+++ b/test/subscription_flow_test.dart
@@ -25,9 +25,11 @@ void main() {
             case 'getSubscriptions':
               final args = methodCall.arguments;
               final productIds = args is Map
-                  ? (args['productIds'] as List?)?.cast<String>()
-                  : args is List
-                      ? args.cast<String>()
+                  ? (args['productIds'] as Iterable?)
+                      ?.map((e) => e.toString())
+                      .toList()
+                  : args is Iterable
+                      ? args.map((e) => e.toString()).toList()
                       : null;
               final allSubs = _getMockSubscriptions();
               final filteredSubs = productIds != null

--- a/test/subscription_flow_test.dart
+++ b/test/subscription_flow_test.dart
@@ -24,10 +24,10 @@ void main() {
               return true;
             case 'getSubscriptions':
               final args = methodCall.arguments;
-              final productIds = args is Map 
+              final productIds = args is Map
                   ? (args['productIds'] as List?)?.cast<String>()
-                  : args is List 
-                      ? args.cast<String>() 
+                  : args is List
+                      ? args.cast<String>()
                       : null;
               final allSubs = _getMockSubscriptions();
               final filteredSubs = productIds != null

--- a/test/subscription_flow_test.dart
+++ b/test/subscription_flow_test.dart
@@ -24,7 +24,11 @@ void main() {
               return true;
             case 'getSubscriptions':
               final args = methodCall.arguments;
-              final productIds = args is List ? args.cast<String>() : null;
+              final productIds = args is Map 
+                  ? (args['productIds'] as List?)?.cast<String>()
+                  : args is List 
+                      ? args.cast<String>() 
+                      : null;
               final allSubs = _getMockSubscriptions();
               final filteredSubs = productIds != null
                   ? allSubs


### PR DESCRIPTION
- **Android Subscription Loading**: Fixed type casting error when loading subscriptions
  - Fixed `_Map<String, dynamic>` type casting issue that prevented subscriptions from loading
  - Improved handling of pricing phases data structure from Android
  - Fixed parsing of subscription offer details from nested JSON structure
- **Test Product Cleanup**: Removed deprecated `android.test.purchased` test product ID
  - This test ID is no longer valid in Google Play Billing Library 6+
- **Type Safety**: Improved type handling for Map conversions from native platforms
  - Better handling of different Map implementations from iOS and Android

Resolve #526 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android subscription loading/parsing issues, improved cross‑platform type safety, and removed deprecated Android test product IDs.
* **New Features**
  * Richer subscription UI in the example app: product detail modal, current-subscription badge, restore/purchase tooling, and Android proration mode selector.
* **Documentation**
  * README and release notes added for v6.3.1; new iOS purchase-state detection and troubleshooting guides.
* **Tests**
  * Tests accept both list and map inputs for product ID filtering.
* **Chores**
  * Version bumped to 6.3.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->