### PR TITLE
fix: parse JSON response from Android finishTransaction methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ docs/node_modules/
 !.vscode/tasks.json
 !.vscode/settings.json
 !.vscode/extensions.json
+
+# Android build artifacts
+example/android/app/.cxx/
+*.cxx/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 6.4.4
+
+### Bug Fixes
+
+- **Android**: Fixed FormatException when calling finishTransaction ([#539](https://github.com/hyochan/flutter_inapp_purchase/issues/539))
+
 ## 6.4.3
 
 ### Bug Fixes

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -11,12 +11,14 @@ import 'types.dart' as iap_types;
 import 'modules/ios.dart';
 import 'modules/android.dart';
 import 'builders.dart';
+import 'utils.dart';
 
 export 'types.dart';
 export 'enums.dart';
 export 'errors.dart';
 export 'events.dart';
 export 'builders.dart';
+export 'utils.dart';
 
 // Enums moved to enums.dart
 
@@ -1424,23 +1426,13 @@ class FlutterInappPurchase
             await _channel.invokeMethod('consumeProduct', <String, dynamic>{
           'purchaseToken': purchase.purchaseToken,
         });
-        // Android returns a JSON string, parse it to validate the response
-        if (result != null && result is String) {
-          try {
-            final response = jsonDecode(result) as Map<String, dynamic>;
-            if (kDebugMode) {
-              debugPrint(
-                '[FlutterInappPurchase] Android: Product consumed successfully. Response code: ${response['responseCode']}',
-              );
-            }
-          } catch (e) {
-            if (kDebugMode) {
-              debugPrint(
-                '[FlutterInappPurchase] Android: Failed to parse consume response: $e',
-              );
-            }
-          }
-        }
+        parseAndLogAndroidResponse(
+          result,
+          successLog:
+              '[FlutterInappPurchase] Android: Product consumed successfully',
+          failureLog:
+              '[FlutterInappPurchase] Android: Failed to parse consume response',
+        );
         return;
       } else {
         if (purchase.isAcknowledgedAndroid == true) {
@@ -1464,23 +1456,13 @@ class FlutterInappPurchase
               .invokeMethod('acknowledgePurchase', <String, dynamic>{
             'purchaseToken': purchase.purchaseToken,
           });
-          // Android returns a JSON string, parse it to validate the response
-          if (result != null && result is String) {
-            try {
-              final response = jsonDecode(result) as Map<String, dynamic>;
-              if (kDebugMode) {
-                debugPrint(
-                  '[FlutterInappPurchase] Android: Purchase acknowledged successfully. Response code: ${response['responseCode']}',
-                );
-              }
-            } catch (e) {
-              if (kDebugMode) {
-                debugPrint(
-                  '[FlutterInappPurchase] Android: Failed to parse acknowledge response: $e',
-                );
-              }
-            }
-          }
+          parseAndLogAndroidResponse(
+            result,
+            successLog:
+                '[FlutterInappPurchase] Android: Purchase acknowledged successfully',
+            failureLog:
+                '[FlutterInappPurchase] Android: Failed to parse acknowledge response',
+          );
           return;
         }
       }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -1420,9 +1420,27 @@ class FlutterInappPurchase
         debugPrint(
           '[FlutterInappPurchase] Android: Consuming product with token: ${purchase.purchaseToken}',
         );
-        await _channel.invokeMethod('consumeProduct', <String, dynamic>{
+        final result =
+            await _channel.invokeMethod('consumeProduct', <String, dynamic>{
           'purchaseToken': purchase.purchaseToken,
         });
+        // Android returns a JSON string, parse it to validate the response
+        if (result != null && result is String) {
+          try {
+            final response = jsonDecode(result) as Map<String, dynamic>;
+            if (kDebugMode) {
+              debugPrint(
+                '[FlutterInappPurchase] Android: Product consumed successfully. Response code: ${response['responseCode']}',
+              );
+            }
+          } catch (e) {
+            if (kDebugMode) {
+              debugPrint(
+                '[FlutterInappPurchase] Android: Failed to parse consume response: $e',
+              );
+            }
+          }
+        }
         return;
       } else {
         if (purchase.isAcknowledgedAndroid == true) {
@@ -1442,9 +1460,27 @@ class FlutterInappPurchase
               '[FlutterInappPurchase] Android: Acknowledging purchase with token: $maskedToken',
             );
           }
-          await _channel.invokeMethod('acknowledgePurchase', <String, dynamic>{
+          final result = await _channel
+              .invokeMethod('acknowledgePurchase', <String, dynamic>{
             'purchaseToken': purchase.purchaseToken,
           });
+          // Android returns a JSON string, parse it to validate the response
+          if (result != null && result is String) {
+            try {
+              final response = jsonDecode(result) as Map<String, dynamic>;
+              if (kDebugMode) {
+                debugPrint(
+                  '[FlutterInappPurchase] Android: Purchase acknowledged successfully. Response code: ${response['responseCode']}',
+                );
+              }
+            } catch (e) {
+              if (kDebugMode) {
+                debugPrint(
+                  '[FlutterInappPurchase] Android: Failed to parse acknowledge response: $e',
+                );
+              }
+            }
+          }
           return;
         }
       }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+
+/// Parse Android JSON response and log the result
+void parseAndLogAndroidResponse(
+  dynamic result, {
+  required String successLog,
+  required String failureLog,
+}) {
+  if (result == null || result is! String) {
+    return;
+  }
+
+  try {
+    final response = jsonDecode(result) as Map<String, dynamic>;
+    if (kDebugMode) {
+      debugPrint(
+        '$successLog. Response code: ${response['responseCode']}',
+      );
+    }
+  } catch (e) {
+    if (kDebugMode) {
+      debugPrint('$failureLog: $e');
+    }
+  }
+}

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -767,11 +767,13 @@ void main() {
             }
             if (methodCall.method == 'consumeProduct') {
               expect(methodCall.arguments['purchaseToken'], isNotNull);
-              return 'consumed';
+              // Return JSON response like actual Android implementation
+              return '{"responseCode":0,"debugMessage":"","code":"OK","message":"","purchaseToken":"${methodCall.arguments['purchaseToken']}"}';
             }
             if (methodCall.method == 'acknowledgePurchase') {
               expect(methodCall.arguments['purchaseToken'], isNotNull);
-              return 'acknowledged';
+              // Return JSON response like actual Android implementation
+              return '{"responseCode":0,"debugMessage":"","code":"OK","message":""}';
             }
             return null;
           });


### PR DESCRIPTION
Fixes FormatException when calling finishTransaction on Android by properly parsing JSON responses from consumeProduct and acknowledgePurchase methods.

Fixes #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None user-visible; behavior unchanged.

- Bug Fixes
  - Fixed an Android crash (FormatException) when finishing purchases.

- Refactor
  - Improved Android purchase handling with additional debug logging for consume/acknowledge flows (no API changes).

- Tests
  - Updated Android purchase mocks to use realistic JSON responses.

- Chores / Documentation
  - Ignored Android C++ build artifacts and added a changelog entry for v6.4.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->