### PR TITLE
Add OpenIAP-compliant receipt validation API

### DIFF
--- a/example/lib/src/screens/available_purchases_screen.dart
+++ b/example/lib/src/screens/available_purchases_screen.dart
@@ -40,12 +40,13 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
         if (existingDate != null) {
           if (existingDate is String) {
             // Try to parse as ISO date string first
-            final dateTime = DateTime.tryParse(existingDate);
+            final dateStr = existingDate as String;
+            final dateTime = DateTime.tryParse(dateStr);
             if (dateTime != null) {
               existingTimestamp = dateTime.millisecondsSinceEpoch;
             } else {
               // Try to parse as milliseconds string
-              existingTimestamp = int.tryParse(existingDate) ?? 0;
+              existingTimestamp = int.tryParse(dateStr) ?? 0;
             }
           } else if (existingDate is num) {
             existingTimestamp = existingDate.toInt();
@@ -55,12 +56,13 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
         if (newDate != null) {
           if (newDate is String) {
             // Try to parse as ISO date string first
-            final dateTime = DateTime.tryParse(newDate);
+            final dateStr = newDate as String;
+            final dateTime = DateTime.tryParse(dateStr);
             if (dateTime != null) {
               newTimestamp = dateTime.millisecondsSinceEpoch;
             } else {
               // Try to parse as milliseconds string
-              newTimestamp = int.tryParse(newDate) ?? 0;
+              newTimestamp = int.tryParse(dateStr) ?? 0;
             }
           } else if (newDate is num) {
             newTimestamp = newDate.toInt();

--- a/example/lib/src/screens/available_purchases_screen.dart
+++ b/example/lib/src/screens/available_purchases_screen.dart
@@ -30,22 +30,41 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
         uniquePurchases[purchase.productId] = purchase;
       } else {
         // Keep the most recent transaction
-        final existingDate = existingPurchase.transactionDate ?? 0;
-        final newDate = purchase.transactionDate ?? 0;
+        final existingDate = existingPurchase.transactionDate;
+        final newDate = purchase.transactionDate;
 
         int existingTimestamp = 0;
         int newTimestamp = 0;
 
-        if (existingDate is String) {
-          existingTimestamp = int.tryParse(existingDate as String) ?? 0;
-        } else {
-          existingTimestamp = (existingDate as num).toInt();
+        // Handle different types of date values
+        if (existingDate != null) {
+          if (existingDate is String) {
+            // Try to parse as ISO date string first
+            final dateTime = DateTime.tryParse(existingDate);
+            if (dateTime != null) {
+              existingTimestamp = dateTime.millisecondsSinceEpoch;
+            } else {
+              // Try to parse as milliseconds string
+              existingTimestamp = int.tryParse(existingDate) ?? 0;
+            }
+          } else if (existingDate is num) {
+            existingTimestamp = existingDate.toInt();
+          }
         }
 
-        if (newDate is String) {
-          newTimestamp = int.tryParse(newDate as String) ?? 0;
-        } else {
-          newTimestamp = (newDate as num).toInt();
+        if (newDate != null) {
+          if (newDate is String) {
+            // Try to parse as ISO date string first
+            final dateTime = DateTime.tryParse(newDate);
+            if (dateTime != null) {
+              newTimestamp = dateTime.millisecondsSinceEpoch;
+            } else {
+              // Try to parse as milliseconds string
+              newTimestamp = int.tryParse(newDate) ?? 0;
+            }
+          } else if (newDate is num) {
+            newTimestamp = newDate.toInt();
+          }
         }
 
         if (newTimestamp > existingTimestamp) {

--- a/example/lib/src/screens/available_purchases_screen.dart
+++ b/example/lib/src/screens/available_purchases_screen.dart
@@ -20,6 +20,27 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
   bool _connected = false;
   String? _error;
 
+  /// Convert various date formats to milliseconds timestamp
+  int _parseTimestamp(dynamic date) {
+    if (date == null) return 0;
+
+    if (date is String) {
+      // Try to parse as ISO date string first
+      final dateTime = DateTime.tryParse(date);
+      if (dateTime != null) {
+        return dateTime.millisecondsSinceEpoch;
+      }
+      // Try to parse as milliseconds string
+      return int.tryParse(date) ?? 0;
+    } else if (date is num) {
+      return date.toInt();
+    } else if (date is DateTime) {
+      return date.millisecondsSinceEpoch;
+    }
+
+    return 0;
+  }
+
   /// Remove duplicate purchases by productId, keeping the most recent transaction
   List<Purchase> _deduplicatePurchases(List<Purchase> purchases) {
     final Map<String, Purchase> uniquePurchases = {};
@@ -30,43 +51,9 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
         uniquePurchases[purchase.productId] = purchase;
       } else {
         // Keep the most recent transaction
-        final existingDate = existingPurchase.transactionDate;
-        final newDate = purchase.transactionDate;
-
-        int existingTimestamp = 0;
-        int newTimestamp = 0;
-
-        // Handle different types of date values
-        if (existingDate != null) {
-          if (existingDate is String) {
-            // Try to parse as ISO date string first
-            final dateStr = existingDate as String;
-            final dateTime = DateTime.tryParse(dateStr);
-            if (dateTime != null) {
-              existingTimestamp = dateTime.millisecondsSinceEpoch;
-            } else {
-              // Try to parse as milliseconds string
-              existingTimestamp = int.tryParse(dateStr) ?? 0;
-            }
-          } else
-            existingTimestamp = existingDate.toInt();
-        }
-
-        if (newDate != null) {
-          if (newDate is String) {
-            // Try to parse as ISO date string first
-            final dateStr = newDate as String;
-            final dateTime = DateTime.tryParse(dateStr);
-            if (dateTime != null) {
-              newTimestamp = dateTime.millisecondsSinceEpoch;
-            } else {
-              // Try to parse as milliseconds string
-              newTimestamp = int.tryParse(dateStr) ?? 0;
-            }
-          } else {
-            newTimestamp = newDate.toInt();
-          }
-        }
+        final existingTimestamp =
+            _parseTimestamp(existingPurchase.transactionDate);
+        final newTimestamp = _parseTimestamp(purchase.transactionDate);
 
         if (newTimestamp > existingTimestamp) {
           uniquePurchases[purchase.productId] = purchase;

--- a/example/lib/src/screens/available_purchases_screen.dart
+++ b/example/lib/src/screens/available_purchases_screen.dart
@@ -48,9 +48,8 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
               // Try to parse as milliseconds string
               existingTimestamp = int.tryParse(dateStr) ?? 0;
             }
-          } else if (existingDate is num) {
+          } else
             existingTimestamp = existingDate.toInt();
-          }
         }
 
         if (newDate != null) {
@@ -64,7 +63,7 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
               // Try to parse as milliseconds string
               newTimestamp = int.tryParse(dateStr) ?? 0;
             }
-          } else if (newDate is num) {
+          } else {
             newTimestamp = newDate.toInt();
           }
         }

--- a/example/lib/src/screens/available_purchases_screen.dart
+++ b/example/lib/src/screens/available_purchases_screen.dart
@@ -38,13 +38,15 @@ class _AvailablePurchasesScreenState extends State<AvailablePurchasesScreen> {
 
         if (existingDate is String) {
           existingTimestamp = int.tryParse(existingDate as String) ?? 0;
-        } else
+        } else {
           existingTimestamp = (existingDate as num).toInt();
+        }
 
         if (newDate is String) {
           newTimestamp = int.tryParse(newDate as String) ?? 0;
-        } else
+        } else {
           newTimestamp = (newDate as num).toInt();
+        }
 
         if (newTimestamp > existingTimestamp) {
           uniquePurchases[purchase.productId] = purchase;

--- a/ios/Classes/FlutterInappPurchasePlugin.swift
+++ b/ios/Classes/FlutterInappPurchasePlugin.swift
@@ -186,9 +186,9 @@ public class FlutterInappPurchasePlugin: NSObject, FlutterPlugin {
         processedTransactionIds.insert(transactionId)
         
         var event: [String: Any] = [
-            "id": transactionId as String,  // Ensure String type for OpenIAP compliance
+            "id": transactionId,  // OpenIAP compliance
             "productId": transaction.productID,
-            "transactionId": transactionId as String,  // Ensure String type
+            "transactionId": transactionId,
             "transactionDate": transaction.purchaseDate.timeIntervalSince1970 * 1000,
             "transactionReceipt": transaction.jsonRepresentation.base64EncodedString(),
             "purchaseToken": jwsRepresentation,  // Unified field for iOS JWS and Android purchaseToken
@@ -397,9 +397,9 @@ public class FlutterInappPurchasePlugin: NSObject, FlutterPlugin {
                     print("\(FlutterInappPurchasePlugin.TAG) getAvailableItems - String transactionId: '\(transactionId)'")
                     
                     var purchase: [String: Any] = [
-                        "id": transactionId as String,  // Ensure String type
+                        "id": transactionId,
                         "productId": transaction.productID,
-                        "transactionId": transactionId as String,  // Ensure String type
+                        "transactionId": transactionId,
                         "transactionDate": transaction.purchaseDate.timeIntervalSince1970 * 1000,
                         "transactionReceipt": transaction.jsonRepresentation.base64EncodedString(),
                         "purchaseToken": verificationResult.jwsRepresentation,  // JWS for server validation (iOS 15+)

--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -1,4 +1,5 @@
 /// Error types for flutter_inapp_purchase (OpenIAP compliant)
+library errors;
 
 import 'dart:io';
 import 'enums.dart';

--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -1,5 +1,4 @@
 /// Error types for flutter_inapp_purchase (OpenIAP compliant)
-library;
 
 import 'dart:io';
 import 'enums.dart';

--- a/lib/errors.dart
+++ b/lib/errors.dart
@@ -1,4 +1,5 @@
 /// Error types for flutter_inapp_purchase (OpenIAP compliant)
+library;
 
 import 'dart:io';
 import 'enums.dart';
@@ -92,8 +93,8 @@ class PurchaseError implements Exception {
   final IapPlatform? platform;
 
   PurchaseError({
-    String? name,
     required this.message,
+    String? name,
     this.responseCode,
     this.debugMessage,
     this.code,
@@ -178,14 +179,14 @@ class ErrorCodeUtils {
     IapPlatform platform,
   ) {
     if (platform == IapPlatform.ios) {
-      final mapping = ErrorCodeMapping.ios;
+      const mapping = ErrorCodeMapping.ios;
       for (final entry in mapping.entries) {
         if (entry.value == platformCode) {
           return entry.key;
         }
       }
     } else {
-      final mapping = ErrorCodeMapping.android;
+      const mapping = ErrorCodeMapping.android;
       for (final entry in mapping.entries) {
         if (entry.value == platformCode) {
           return entry.key;

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -1564,7 +1564,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on iOS',
-        platform: iap_types.IapPlatform.ios, // Fixed: should be iOS
+        platform: getCurrentPlatform(),
       );
     }
 
@@ -1572,7 +1572,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'IAP connection not initialized',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(),
       );
     }
 
@@ -1580,7 +1580,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'sku cannot be empty',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(),
       );
     }
 
@@ -1594,7 +1594,7 @@ class FlutterInappPurchase
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'No validation result received from native platform',
-          platform: iap_types.IapPlatform.ios,
+          platform: getCurrentPlatform(),
         );
       }
 
@@ -1620,20 +1620,20 @@ class FlutterInappPurchase
             as String?, // Deprecated, for backward compatibility
         latestTransaction: latestTransaction,
         rawResponse: validationResult,
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(),
       );
     } on PlatformException catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage:
             'Failed to validate receipt [${e.code}]: ${e.message ?? e.details}',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(),
       );
     } catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Failed to validate receipt: ${e.toString()}',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(),
       );
     }
   }
@@ -1697,7 +1697,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Platform not supported for receipt validation',
-        platform: null,
+        platform: getCurrentPlatform(),
       );
     }
   }
@@ -1710,7 +1710,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on Android',
-        platform: iap_types.IapPlatform.android, // Fixed: should be Android
+        platform: getCurrentPlatform(),
       );
     }
 
@@ -1720,7 +1720,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Android options required for Android validation',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(),
       );
     }
 
@@ -1734,7 +1734,7 @@ class FlutterInappPurchase
         isValid: false,
         errorMessage:
             'Invalid parameters: packageName, productToken, and accessToken cannot be empty',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(),
       );
     }
 
@@ -1777,39 +1777,39 @@ class FlutterInappPurchase
           isValid: isValid,
           errorMessage: isValid ? null : 'Purchase is not active/valid',
           rawResponse: responseData,
-          platform: iap_types.IapPlatform.android,
+          platform: getCurrentPlatform(),
         );
       } else if (response.statusCode == 401 || response.statusCode == 403) {
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'Unauthorized/forbidden (check access token/scopes)',
-          platform: iap_types.IapPlatform.android,
+          platform: getCurrentPlatform(),
         );
       } else if (response.statusCode == 404) {
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'Token or SKU not found',
-          platform: iap_types.IapPlatform.android,
+          platform: getCurrentPlatform(),
         );
       } else {
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage:
               'API returned status ${response.statusCode}: ${response.body}',
-          platform: iap_types.IapPlatform.android,
+          platform: getCurrentPlatform(),
         );
       }
     } on TimeoutException {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Request to Google Play API timed out',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(),
       );
     } catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Failed to validate receipt: ${e.toString()}',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(),
       );
     }
   }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -1565,7 +1565,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on iOS',
-        platform: getCurrentPlatform(), // Show actual platform for debugging
+        platform: iap_types.IapPlatform.ios,
       );
     }
 
@@ -1573,7 +1573,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'IAP connection not initialized',
-        platform: getCurrentPlatform(), // Show actual platform for debugging
+        platform: iap_types.IapPlatform.ios,
       );
     }
 
@@ -1581,7 +1581,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'sku cannot be empty',
-        platform: getCurrentPlatform(), // Show actual platform for debugging
+        platform: iap_types.IapPlatform.ios,
       );
     }
 
@@ -1628,13 +1628,15 @@ class FlutterInappPurchase
         isValid: false,
         errorMessage:
             'Failed to validate receipt [${e.code}]: ${e.message ?? e.details}',
-        platform: iap_types.IapPlatform.ios,
+        platform:
+            getCurrentPlatform(), // Show actual platform when exception occurs
       );
     } catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Failed to validate receipt: ${e.toString()}',
-        platform: iap_types.IapPlatform.ios,
+        platform:
+            getCurrentPlatform(), // Show actual platform when exception occurs
       );
     }
   }
@@ -1711,7 +1713,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on Android',
-        platform: getCurrentPlatform(), // Show actual platform for debugging
+        platform: iap_types.IapPlatform.android,
       );
     }
 
@@ -1721,7 +1723,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Android options required for Android validation',
-        platform: getCurrentPlatform(), // Show actual platform for debugging
+        platform: iap_types.IapPlatform.android,
       );
     }
 
@@ -1735,7 +1737,7 @@ class FlutterInappPurchase
         isValid: false,
         errorMessage:
             'Invalid parameters: packageName, productToken, and accessToken cannot be empty',
-        platform: getCurrentPlatform(), // Show actual platform for debugging
+        platform: iap_types.IapPlatform.android,
       );
     }
 
@@ -1804,13 +1806,15 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Request to Google Play API timed out',
-        platform: iap_types.IapPlatform.android,
+        platform:
+            getCurrentPlatform(), // Show actual platform when exception occurs
       );
     } catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Failed to validate receipt: ${e.toString()}',
-        platform: iap_types.IapPlatform.android,
+        platform:
+            getCurrentPlatform(), // Show actual platform when exception occurs
       );
     }
   }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -1498,8 +1498,8 @@ class FlutterInappPurchase
   /// This method uses the legacy Apple verification endpoints which are being phased out.
   /// Please migrate to validateReceiptIOS which uses StoreKit 2 on-device validation.
   @Deprecated(
-    'Use validateReceiptIOS instead for StoreKit 2 on-device validation. '
-    'Apple is phasing out server-side receipt validation endpoints. '
+    'Use validateReceiptIOS for StoreKit 2 on-device validation. '
+    'Server-side verifyReceipt remains supported by Apple but is legacy in this plugin. '
     'Will be removed in v7.0.0',
   )
   Future<http.Response> validateReceiptIos({

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:platform/platform.dart';
 
 import 'enums.dart';
+import 'errors.dart' show getCurrentPlatform;
 import 'types.dart' as iap_types;
 import 'modules/ios.dart';
 import 'modules/android.dart';

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -7,7 +7,6 @@ import 'package:http/http.dart' as http;
 import 'package:platform/platform.dart';
 
 import 'enums.dart';
-import 'errors.dart' show getCurrentPlatform;
 import 'types.dart' as iap_types;
 import 'modules/ios.dart';
 import 'modules/android.dart';
@@ -1565,7 +1564,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on iOS',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.ios,
       );
     }
 
@@ -1573,7 +1572,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'IAP connection not initialized',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.ios,
       );
     }
 
@@ -1581,7 +1580,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'sku cannot be empty',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.ios,
       );
     }
 
@@ -1595,7 +1594,7 @@ class FlutterInappPurchase
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'No validation result received from native platform',
-          platform: getCurrentPlatform(),
+          platform: iap_types.IapPlatform.ios,
         );
       }
 
@@ -1621,20 +1620,20 @@ class FlutterInappPurchase
             as String?, // Deprecated, for backward compatibility
         latestTransaction: latestTransaction,
         rawResponse: validationResult,
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.ios,
       );
     } on PlatformException catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage:
             'Failed to validate receipt [${e.code}]: ${e.message ?? e.details}',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.ios,
       );
     } catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Failed to validate receipt: ${e.toString()}',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.ios,
       );
     }
   }
@@ -1698,7 +1697,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Platform not supported for receipt validation',
-        platform: getCurrentPlatform(),
+        platform: null, // Unknown/unsupported platform
       );
     }
   }
@@ -1711,7 +1710,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on Android',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.android,
       );
     }
 
@@ -1721,7 +1720,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Android options required for Android validation',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.android,
       );
     }
 
@@ -1735,7 +1734,7 @@ class FlutterInappPurchase
         isValid: false,
         errorMessage:
             'Invalid parameters: packageName, productToken, and accessToken cannot be empty',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.android,
       );
     }
 
@@ -1778,39 +1777,39 @@ class FlutterInappPurchase
           isValid: isValid,
           errorMessage: isValid ? null : 'Purchase is not active/valid',
           rawResponse: responseData,
-          platform: getCurrentPlatform(),
+          platform: iap_types.IapPlatform.android,
         );
       } else if (response.statusCode == 401 || response.statusCode == 403) {
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'Unauthorized/forbidden (check access token/scopes)',
-          platform: getCurrentPlatform(),
+          platform: iap_types.IapPlatform.android,
         );
       } else if (response.statusCode == 404) {
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'Token or SKU not found',
-          platform: getCurrentPlatform(),
+          platform: iap_types.IapPlatform.android,
         );
       } else {
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage:
               'API returned status ${response.statusCode}: ${response.body}',
-          platform: getCurrentPlatform(),
+          platform: iap_types.IapPlatform.android,
         );
       }
     } on TimeoutException {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Request to Google Play API timed out',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.android,
       );
     } catch (e) {
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Failed to validate receipt: ${e.toString()}',
-        platform: getCurrentPlatform(),
+        platform: iap_types.IapPlatform.android,
       );
     }
   }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:platform/platform.dart';
 
 import 'enums.dart';
+import 'errors.dart' show getCurrentPlatform;
 import 'types.dart' as iap_types;
 import 'modules/ios.dart';
 import 'modules/android.dart';
@@ -1564,7 +1565,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on iOS',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(), // Show actual platform for debugging
       );
     }
 
@@ -1572,7 +1573,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'IAP connection not initialized',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(), // Show actual platform for debugging
       );
     }
 
@@ -1580,7 +1581,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'sku cannot be empty',
-        platform: iap_types.IapPlatform.ios,
+        platform: getCurrentPlatform(), // Show actual platform for debugging
       );
     }
 
@@ -1594,7 +1595,7 @@ class FlutterInappPurchase
         return iap_types.ReceiptValidationResult(
           isValid: false,
           errorMessage: 'No validation result received from native platform',
-          platform: iap_types.IapPlatform.ios,
+          platform: iap_types.IapPlatform.ios, // This is iOS validation
         );
       }
 
@@ -1710,7 +1711,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Receipt validation is only available on Android',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(), // Show actual platform for debugging
       );
     }
 
@@ -1720,7 +1721,7 @@ class FlutterInappPurchase
       return iap_types.ReceiptValidationResult(
         isValid: false,
         errorMessage: 'Android options required for Android validation',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(), // Show actual platform for debugging
       );
     }
 
@@ -1734,7 +1735,7 @@ class FlutterInappPurchase
         isValid: false,
         errorMessage:
             'Invalid parameters: packageName, productToken, and accessToken cannot be empty',
-        platform: iap_types.IapPlatform.android,
+        platform: getCurrentPlatform(), // Show actual platform for debugging
       );
     }
 

--- a/lib/types.dart
+++ b/lib/types.dart
@@ -2635,6 +2635,161 @@ class ValidationResult {
 
 // ReplacementMode enum is defined in enums.dart to avoid duplication
 
+/// Receipt validation properties (OpenIAP compliant)
+class ReceiptValidationProps {
+  /// Product SKU to validate (required for both iOS and Android)
+  final String sku;
+
+  /// Android-specific validation options
+  final AndroidValidationOptions? androidOptions;
+
+  ReceiptValidationProps({
+    required this.sku,
+    this.androidOptions,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'productId': sku, // Use productId for backward compatibility
+      'sku': sku,
+      if (androidOptions != null) 'androidOptions': androidOptions!.toJson(),
+    };
+  }
+
+  factory ReceiptValidationProps.fromJson(Map<String, dynamic> json) {
+    return ReceiptValidationProps(
+      sku: json['sku'] as String? ??
+          json['productId'] as String, // Support both sku and productId
+      androidOptions: json['androidOptions'] != null
+          ? AndroidValidationOptions.fromJson(
+              Map<String, dynamic>.from(json['androidOptions'] as Map),
+            )
+          : null,
+    );
+  }
+}
+
+/// Android-specific validation options for receipt validation
+class AndroidValidationOptions {
+  /// Package name of your Android app
+  final String packageName;
+
+  /// Purchase token for validation (from the purchase)
+  final String productToken;
+
+  /// OAuth access token with androidpublisher scope
+  /// WARNING: Including this in production builds is dangerous!
+  final String accessToken;
+
+  /// Whether this is a subscription (true) or in-app product (false)
+  final bool isSub;
+
+  AndroidValidationOptions({
+    required this.packageName,
+    required this.productToken,
+    required this.accessToken,
+    this.isSub = false,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'packageName': packageName,
+      'productToken': productToken,
+      'accessToken': accessToken,
+      'isSub': isSub,
+    };
+  }
+
+  factory AndroidValidationOptions.fromJson(Map<String, dynamic> json) {
+    return AndroidValidationOptions(
+      packageName: json['packageName'] as String,
+      productToken: json['productToken'] as String,
+      accessToken: json['accessToken'] as String,
+      isSub: json['isSub'] as bool? ?? false,
+    );
+  }
+}
+
+/// Receipt validation result (OpenIAP compliant)
+class ReceiptValidationResult {
+  /// Whether the receipt is valid
+  final bool isValid;
+
+  /// Error message if validation failed
+  final String? errorMessage;
+
+  /// Base64 encoded receipt data (iOS legacy)
+  final String? receiptData;
+
+  /// Unified purchase token field (JWS for iOS, purchase token for Android)
+  final String? purchaseToken;
+
+  /// JWS representation (iOS StoreKit 2) - DEPRECATED: Use purchaseToken instead
+  @Deprecated('Use purchaseToken instead. Will be removed in v7.0.0')
+  final String? jwsRepresentation;
+
+  /// Latest transaction information (StoreKit 2)
+  final Map<String, dynamic>? latestTransaction;
+
+  /// Raw validation response from platform
+  final Map<String, dynamic>? rawResponse;
+
+  /// Platform that performed the validation
+  final IapPlatform? platform;
+
+  ReceiptValidationResult({
+    required this.isValid,
+    this.errorMessage,
+    this.receiptData,
+    this.purchaseToken,
+    this.jwsRepresentation,
+    this.latestTransaction,
+    this.rawResponse,
+    this.platform,
+  });
+
+  factory ReceiptValidationResult.fromJson(Map<String, dynamic> json) {
+    return ReceiptValidationResult(
+      isValid: json['isValid'] as bool? ?? false,
+      errorMessage: json['errorMessage'] as String?,
+      receiptData: json['receiptData'] as String?,
+      purchaseToken: json['purchaseToken'] as String?,
+      jwsRepresentation: json['jwsRepresentation']
+          as String?, // Kept for backward compatibility
+      latestTransaction: json['latestTransaction'] != null
+          ? Map<String, dynamic>.from(json['latestTransaction'] as Map)
+          : null,
+      rawResponse: json['rawResponse'] != null
+          ? Map<String, dynamic>.from(json['rawResponse'] as Map)
+          : null,
+      platform: json['platform'] != null
+          ? (json['platform'] == 'ios' ? IapPlatform.ios : IapPlatform.android)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'isValid': isValid,
+      if (errorMessage != null) 'errorMessage': errorMessage,
+      if (receiptData != null) 'receiptData': receiptData,
+      if (purchaseToken != null) 'purchaseToken': purchaseToken,
+      if (jwsRepresentation != null)
+        'jwsRepresentation':
+            jwsRepresentation, // Kept for backward compatibility
+      if (latestTransaction != null) 'latestTransaction': latestTransaction,
+      if (rawResponse != null) 'rawResponse': rawResponse,
+      if (platform != null)
+        'platform': platform == IapPlatform.ios ? 'ios' : 'android',
+    };
+  }
+
+  @override
+  String toString() {
+    return 'ReceiptValidationResult{isValid: $isValid, errorMessage: $errorMessage, platform: ${platform == IapPlatform.ios ? 'ios' : 'android'}}';
+  }
+}
+
 /// Deep link options (OpenIAP compliant)
 class DeepLinkOptions {
   final String? scheme;

--- a/lib/types.dart
+++ b/lib/types.dart
@@ -2657,9 +2657,12 @@ class ReceiptValidationProps {
   }
 
   factory ReceiptValidationProps.fromJson(Map<String, dynamic> json) {
+    final sku = json['sku'] as String? ?? json['productId'] as String?;
+    if (sku == null) {
+      throw ArgumentError('Either sku or productId must be provided');
+    }
     return ReceiptValidationProps(
-      sku: json['sku'] as String? ??
-          json['productId'] as String, // Support both sku and productId
+      sku: sku,
       androidOptions: json['androidOptions'] != null
           ? AndroidValidationOptions.fromJson(
               Map<String, dynamic>.from(json['androidOptions'] as Map),
@@ -2695,7 +2698,8 @@ class AndroidValidationOptions {
     return {
       'packageName': packageName,
       'productToken': productToken,
-      'accessToken': accessToken,
+      // Do not include accessToken in toJson for security reasons
+      // accessToken should only be used server-side
       'isSub': isSub,
     };
   }
@@ -2786,7 +2790,10 @@ class ReceiptValidationResult {
 
   @override
   String toString() {
-    return 'ReceiptValidationResult{isValid: $isValid, errorMessage: $errorMessage, platform: ${platform == IapPlatform.ios ? 'ios' : 'android'}}';
+    final platformStr = platform == null
+        ? 'unknown'
+        : (platform == IapPlatform.ios ? 'ios' : 'android');
+    return 'ReceiptValidationResult{isValid: $isValid, errorMessage: $errorMessage, platform: $platformStr}';
   }
 }
 


### PR DESCRIPTION
Implements unified receipt validation API following OpenIAP specification with StoreKit 2 support for iOS and Google Play validation for Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-device iOS receipt validation (StoreKit 2) with rich, server-ready transaction payloads.
  * Unified cross-platform validateReceipt API returning a typed ReceiptValidationResult and Android support via Google Play.
  * New public types for receipt validation and deep-link options.

* **Bug Fixes**
  * Purchases list now deduplicates by product, showing only unique active purchases.
  * Restore dialog reports the number of unique purchases.

* **Chores**
  * Deprecated legacy receipt-validation paths; minor error-constructor adjustment in public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->