### PR TITLE
iOS: bump openiap to 1.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 6.5.2
+
+### Changed
+
+- iOS: bump OpenIAP Apple native module to `openiap ~> 1.1.9`.
+
+### Notes
+
+- Example iOS Podfile pins tag `1.1.9`; run `cd example/ios && pod install` to refresh lockfile.
+
 ## 6.5.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ await iap.requestPurchase(
 
 ### iOS Notes
 
-- This plugin uses the OpenIAP Apple native module via CocoaPods (`openiap ~> 1.1.8`).
+- This plugin uses the OpenIAP Apple native module via CocoaPods (`openiap ~> 1.1.9`).
 - After upgrading, run `pod install` in your iOS project (e.g., `example/ios`).
 - Minimum iOS deployment target is `15.0` for StoreKit 2 support.
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,4 +1,4 @@
-# CocoaPods trunk CDN (ensures latest specs like openiap 1.1.8)
+# CocoaPods trunk CDN (ensures latest specs like openiap 1.1.9)
 source 'https://cdn.cocoapods.org/'
 
 # Uncomment this line to define a global platform for your project
@@ -32,8 +32,8 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   use_frameworks!
-  # Ensure openiap resolves to 1.1.8 even if trunk index is lagging
-  pod 'openiap', :git => 'https://github.com/hyodotdev/openiap-apple.git', :tag => '1.1.8'
+  # Ensure openiap resolves to 1.1.9 even if trunk index is lagging
+  pod 'openiap', :git => 'https://github.com/hyodotdev/openiap-apple.git', :tag => '1.1.9'
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - Flutter (1.0.0)
   - flutter_inapp_purchase (0.0.1):
     - Flutter
-    - openiap (~> 1.1.8)
-  - openiap (1.1.8)
+    - openiap (~> 1.1.9)
+  - openiap (1.1.9)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_inapp_purchase (from `.symlinks/plugins/flutter_inapp_purchase/ios`)
-  - openiap (from `https://github.com/hyodotdev/openiap-apple.git`, tag `1.1.8`)
+  - openiap (from `https://github.com/hyodotdev/openiap-apple.git`, tag `1.1.9`)
 
 EXTERNAL SOURCES:
   Flutter:
@@ -17,18 +17,18 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_inapp_purchase/ios"
   openiap:
     :git: https://github.com/hyodotdev/openiap-apple.git
-    :tag: 1.1.8
+    :tag: 1.1.9
 
 CHECKOUT OPTIONS:
   openiap:
     :git: https://github.com/hyodotdev/openiap-apple.git
-    :tag: 1.1.8
+    :tag: 1.1.9
 
 SPEC CHECKSUMS:
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_inapp_purchase: 5fb56c25ce78548a1a1937495c80fece5dc8b911
-  openiap: ef0efeb0505ffcdb576f3c2bef875c10548461e5
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_inapp_purchase: 796b901ba698e052016c07c3fc4bc2d2e9db13c9
+  openiap: dcfa2a4dcf31259ec4b73658e7d1441babccce66
 
-PODFILE CHECKSUM: 90f8ac909b6a441914a9b5a23babe58af6c9fd6c
+PODFILE CHECKSUM: 7f77729f2fac4d8b3c65d064abe240d5bd87fe01
 
 COCOAPODS: 1.16.2

--- a/ios/flutter_inapp_purchase.podspec
+++ b/ios/flutter_inapp_purchase.podspec
@@ -15,8 +15,8 @@ In App Purchase plugin for flutter. This project has been forked by react-native
   s.source_files = 'Classes/**/*.swift'
   s.dependency 'Flutter'
   # Use OpenIAP Apple native module (via CocoaPods)
-  # Require 1.1.8 (and allow 1.1.x updates)
-  s.dependency 'openiap', '~> 1.1.8'
+  # Require 1.1.9 (and allow 1.1.x updates)
+  s.dependency 'openiap', '~> 1.1.9'
   
   s.ios.deployment_target = '15.0'
   s.swift_version = '5.5'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_inapp_purchase
 description: In App Purchase plugin for flutter. This project has been forked by
   react-native-iap and we are willing to share same experience with that on
   react-native.
-version: 6.5.1
+version: 6.5.2
 homepage: https://github.com/hyochan/flutter_inapp_purchase/blob/main/pubspec.yaml
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Upgrade OpenIAP Apple dependency to 1.1.9 and refresh references in podspec, example Podfile, README, and CHANGELOG.

**No breaking changes.** Reflects 1.1.9 release: https://github.com/hyodotdev/openiap-apple/releases/tag/1.1.9