### PR TITLE
migrate purchaseditem to purchase

### DIFF
--- a/docs/docs/api/classes/flutter-inapp-purchase.md
+++ b/docs/docs/api/classes/flutter-inapp-purchase.md
@@ -24,7 +24,7 @@ The singleton instance of the FlutterInappPurchase class.
 ### Streams
 
 ```dart
-Stream<PurchasedItem?> purchaseUpdated
+Stream<Purchase?> purchaseUpdated
 ```
 
 Stream that emits purchase updates when a transaction state changes.
@@ -325,7 +325,7 @@ class StoreService {
     );
   }
 
-  void _handlePurchase(PurchasedItem purchase) {
+  void _handlePurchase(Purchase purchase) {
     // Process the purchase
     print('Purchase completed: ${purchase.productId}');
   }

--- a/docs/docs/api/core-methods.md
+++ b/docs/docs/api/core-methods.md
@@ -286,14 +286,14 @@ Completes a transaction after successful purchase processing.
 
 ```dart
 Future<void> finishTransaction(
-  PurchasedItem purchase, {
+  Purchase purchase, {
   bool isConsumable = false,
 }) async
 ```
 
 **Parameters**:
 
-- `purchase` - The purchased item to finish
+- `purchase` - The purchase to finish
 - `isConsumable` - Whether the product is consumable (Android only)
 
 **Example**:

--- a/docs/docs/api/flutter-inapp-purchase.md
+++ b/docs/docs/api/flutter-inapp-purchase.md
@@ -198,10 +198,10 @@ await FlutterInappPurchase.instance.requestPurchaseSimple(
 Get all non-consumed purchases (restore purchases).
 
 ```dart
-Future<List<PurchasedItem>?> getAvailablePurchases()
+Future<List<Purchase>> getAvailablePurchases()
 ```
 
-**Returns:** `Future<List<PurchasedItem>?>` - List of available purchases
+**Returns:** `Future<List<Purchase>>` - List of available purchases
 
 **Example:**
 
@@ -221,10 +221,10 @@ if (purchases != null) {
 Get purchase history (including consumed purchases on Android).
 
 ```dart
-Future<List<PurchasedItem>?> getPurchaseHistory()
+Future<List<Purchase>> getPurchaseHistory()
 ```
 
-**Returns:** `Future<List<PurchasedItem>?>` - List of purchase history
+**Returns:** `Future<List<Purchase>>` - List of purchase history
 
 ## ✅ Transaction Completion
 
@@ -233,14 +233,14 @@ Future<List<PurchasedItem>?> getPurchaseHistory()
 Complete a transaction (cross-platform).
 
 ```dart
-Future<String?> finishTransaction(PurchasedItem purchase, {bool? isConsumable})
+Future<void> finishTransaction(Purchase purchase, {bool isConsumable = false})
 ```
 
 **Parameters:**
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `purchase` | `PurchasedItem` | ✅ | Purchase to finish |
-| `isConsumable` | `bool?` | ❌ | Whether the purchase is consumable (Android) |
+| `purchase` | `Purchase` | ✅ | Purchase to finish |
+| `isConsumable` | `bool` | ❌ | Whether the purchase is consumable (Android) |
 
 **Example:**
 
@@ -313,7 +313,7 @@ Future<BillingClientState> getConnectionStateAndroid()
 Stream of purchase updates.
 
 ```dart
-Stream<PurchasedItem?> get purchaseUpdated
+Stream<Purchase?> get purchaseUpdated
 ```
 
 **Example:**

--- a/docs/docs/api/listeners.md
+++ b/docs/docs/api/listeners.md
@@ -14,16 +14,16 @@ Real-time event streams for monitoring purchase transactions, connection states,
 Stream for successful purchase completions.
 
 ```dart
-static Stream<PurchasedItem?> get purchaseUpdated
+static Stream<Purchase?> get purchaseUpdated
 ```
 
-**Type**: `Stream<PurchasedItem?>`  
+**Type**: `Stream<Purchase?>`  
 **Emits**: Purchase completion events  
 **Null Safety**: Can emit null values - always check for null
 
 **Example**:
 ```dart
-StreamSubscription<PurchasedItem?>? _purchaseSubscription;
+StreamSubscription<Purchase?>? _purchaseSubscription;
 
 void setupPurchaseListener() {
   _purchaseSubscription = FlutterInappPurchase.purchaseUpdated.listen(
@@ -38,7 +38,7 @@ void setupPurchaseListener() {
   );
 }
 
-Future<void> handlePurchaseSuccess(PurchasedItem purchase) async {
+Future<void> handlePurchaseSuccess(Purchase purchase) async {
   print('Purchase completed: ${purchase.productId}');
   
   try {
@@ -314,7 +314,7 @@ void handleInAppMessage(int messageType) {
 
 ```dart
 class IAPListenerManager {
-  StreamSubscription<PurchasedItem?>? _purchaseSubscription;
+  StreamSubscription<Purchase?>? _purchaseSubscription;
   StreamSubscription<PurchaseResult?>? _errorSubscription;
   StreamSubscription<ConnectionResult>? _connectionSubscription;
   StreamSubscription<String?>? _promotedSubscription;
@@ -402,7 +402,7 @@ class IAPListenerManager {
     print('IAP listeners stopped');
   }
   
-  Future<void> _handlePurchaseSuccess(PurchasedItem purchase) async {
+  Future<void> _handlePurchaseSuccess(Purchase purchase) async {
     // Implementation from examples above
   }
   

--- a/docs/docs/api/methods/finish-transaction.md
+++ b/docs/docs/api/methods/finish-transaction.md
@@ -22,7 +22,7 @@ Future<String?> finishTransaction(Purchase purchase, {bool isConsumable = false}
 ### Legacy Method
 
 ```dart
-Future<String?> finishTransactionIOS(PurchasedItem purchasedItem, {bool isConsumable = false})
+Future<String?> finishTransactionIOS(Purchase purchasedItem, {bool isConsumable = false})
 ```
 
 ## Parameters
@@ -50,15 +50,15 @@ Future<String?> finishTransactionIOS(PurchasedItem purchasedItem, {bool isConsum
 
 ```dart
 // Listen for purchases and finish them
-FlutterInappPurchase.purchaseUpdated.listen((PurchasedItem? item) async {
-  if (item != null) {
+FlutterInappPurchase.purchaseUpdated.listen((Purchase? purchase) async {
+  if (purchase != null) {
     // Verify and deliver content
-    await _verifyAndDeliver(item);
+    await _verifyAndDeliver(purchase);
 
     // Finish the transaction
     await FlutterInappPurchase.instance.finishTransactionIOS(
-      item,
-      isConsumable: _isConsumable(item.productId),
+      purchase,
+      isConsumable: _isConsumable(purchase.productId),
     );
   }
 });
@@ -91,23 +91,23 @@ class PurchaseHandler {
     FlutterInappPurchase.purchaseUpdated.listen(_handlePurchase);
   }
 
-  Future<void> _handlePurchase(PurchasedItem? item) async {
-    if (item == null) return;
+  Future<void> _handlePurchase(Purchase? purchase) async {
+    if (purchase == null) return;
 
     try {
       // Step 1: Verify the purchase
-      final isValid = await _verifyPurchase(item);
+      final isValid = await _verifyPurchase(purchase);
       if (!isValid) {
         print('Invalid purchase detected');
         return;
       }
 
       // Step 2: Deliver the content
-      await _deliverContent(item.productId!);
+      await _deliverContent(purchase.productId!);
 
       // Step 3: Finish the transaction
-      final isConsumable = _consumableIds.contains(item.productId);
-      await _iap.finishTransactionIOS(item, isConsumable: isConsumable);
+      final isConsumable = _consumableIds.contains(purchase.productId);
+      await _iap.finishTransactionIOS(purchase, isConsumable: isConsumable);
 
       print('Transaction completed successfully');
 
@@ -118,7 +118,7 @@ class PurchaseHandler {
     }
   }
 
-  Future<bool> _verifyPurchase(PurchasedItem item) async {
+  Future<bool> _verifyPurchase(Purchase item) async {
     // Implement your verification logic
     // - Verify receipt with your backend
     // - Check transaction ID uniqueness
@@ -146,7 +146,7 @@ class PurchaseHandler {
 ## Android-Specific Handling
 
 ```dart
-Future<void> handleAndroidPurchase(PurchasedItem item) async {
+Future<void> handleAndroidPurchase(Purchase item) async {
   if (!Platform.isAndroid) return;
 
   // Check acknowledgment status
@@ -188,7 +188,7 @@ class TransactionManager {
     }
   }
 
-  Future<void> _processPendingTransaction(PurchasedItem item) async {
+  Future<void> _processPendingTransaction(Purchase item) async {
     // Verify the transaction
     final isValid = await _verifyTransaction(item);
 
@@ -216,7 +216,7 @@ class TransactionManager {
 ## Error Handling
 
 ```dart
-Future<void> safeFinishTransaction(PurchasedItem item) async {
+Future<void> safeFinishTransaction(Purchase item) async {
   const maxRetries = 3;
   var retryCount = 0;
 
@@ -251,7 +251,7 @@ Future<void> safeFinishTransaction(PurchasedItem item) async {
 Monitor transaction states for proper handling:
 
 ```dart
-void handleTransactionState(PurchasedItem item) {
+void handleTransactionState(Purchase item) {
   if (Platform.isIOS) {
     switch (item.transactionStateIOS) {
       case TransactionState.purchased:

--- a/docs/docs/api/methods/get-available-purchases.md
+++ b/docs/docs/api/methods/get-available-purchases.md
@@ -20,7 +20,7 @@ Future<List<Purchase>> getAvailablePurchases()
 
 ### Legacy Method
 ```dart
-Future<List<PurchasedItem>?> getAvailableItemsIOS()
+Future<List<Purchase>?> getAvailableItemsIOS()
 ```
 
 ## Returns

--- a/docs/docs/api/methods/request-purchase.md
+++ b/docs/docs/api/methods/request-purchase.md
@@ -192,18 +192,18 @@ Purchase results are delivered through streams:
 
 ```dart
 // Listen to successful purchases
-FlutterInappPurchase.purchaseUpdated.listen((PurchasedItem? item) {
-  if (item != null) {
-    print('Purchase successful: ${item.productId}');
+FlutterInappPurchase.purchaseUpdated.listen((Purchase? purchase) {
+  if (purchase != null) {
+    print('Purchase successful: ${purchase.productId}');
     
     // Verify the purchase
-    _verifyPurchase(item);
+    _verifyPurchase(purchase);
     
     // Deliver the content
-    _deliverContent(item.productId);
+    _deliverContent(purchase.productId);
     
     // Finish the transaction
-    _finishTransaction(item);
+    _finishTransaction(purchase);
   }
 });
 

--- a/docs/docs/api/methods/request-subscription.md
+++ b/docs/docs/api/methods/request-subscription.md
@@ -154,20 +154,20 @@ await _iap.requestSubscription(
 ```dart
 void setupSubscriptionListeners() {
   // Listen for successful subscriptions
-  FlutterInappPurchase.purchaseUpdated.listen((PurchasedItem? item) {
-    if (item != null && _isSubscription(item.productId)) {
-      print('Subscription successful: ${item.productId}');
+  FlutterInappPurchase.purchaseUpdated.listen((Purchase? purchase) {
+    if (purchase != null && _isSubscription(purchase.productId)) {
+      print('Subscription successful: ${purchase.productId}');
       
       // Store the token for future upgrades
       if (Platform.isAndroid) {
-        _currentSubscriptionToken = item.purchaseToken;
+        _currentSubscriptionToken = purchase.purchaseToken;
       }
       
       // Verify and activate subscription
-      _activateSubscription(item);
+      _activateSubscription(purchase);
       
       // Finish the transaction
-      _iap.finishTransactionIOS(item);
+      _iap.finishTransactionIOS(purchase);
     }
   });
   

--- a/docs/docs/api/methods/validate-receipt.md
+++ b/docs/docs/api/methods/validate-receipt.md
@@ -87,7 +87,7 @@ class IosReceiptValidator {
   
   IosReceiptValidator({required this.sharedSecret});
   
-  Future<ReceiptValidationResult> validate(PurchasedItem purchase) async {
+  Future<ReceiptValidationResult> validate(Purchase purchase) async {
     if (purchase.transactionReceipt == null) {
       return ReceiptValidationResult(
         isValid: false,
@@ -189,7 +189,7 @@ class IosReceiptValidator {
 ### Basic Usage
 
 ```dart
-Future<bool> validateAndroidReceipt(PurchasedItem purchase) async {
+Future<bool> validateAndroidReceipt(Purchase purchase) async {
   try {
     // Get access token (implement OAuth 2.0 flow)
     final accessToken = await _getGoogleAccessToken();
@@ -233,7 +233,7 @@ class AndroidReceiptValidator {
     required this.authService,
   });
   
-  Future<ReceiptValidationResult> validate(PurchasedItem purchase) async {
+  Future<ReceiptValidationResult> validate(Purchase purchase) async {
     if (purchase.purchaseToken == null) {
       return ReceiptValidationResult(
         isValid: false,
@@ -265,7 +265,7 @@ class AndroidReceiptValidator {
   
   ReceiptValidationResult _parseResponse(
     http.Response response,
-    PurchasedItem purchase,
+    Purchase purchase,
   ) {
     if (response.statusCode == 404) {
       return ReceiptValidationResult(
@@ -337,7 +337,7 @@ class ServerReceiptValidator {
     required this.httpClient,
   });
   
-  Future<bool> validate(PurchasedItem purchase) async {
+  Future<bool> validate(Purchase purchase) async {
     try {
       final payload = {
         'platform': Platform.isIOS ? 'ios' : 'android',
@@ -382,7 +382,7 @@ class PurchaseValidator {
   final IosReceiptValidator iosValidator;
   final AndroidReceiptValidator androidValidator;
   
-  Future<void> validatePurchase(PurchasedItem purchase) async {
+  Future<void> validatePurchase(Purchase purchase) async {
     try {
       // Always prefer server-side validation
       if (await serverValidator.validate(purchase)) {
@@ -414,7 +414,7 @@ class PurchaseValidator {
     }
   }
   
-  Future<void> _completePurchase(PurchasedItem purchase) async {
+  Future<void> _completePurchase(Purchase purchase) async {
     // Deliver content
     await _deliverContent(purchase.productId!);
     

--- a/docs/docs/api/overview.md
+++ b/docs/docs/api/overview.md
@@ -29,7 +29,7 @@ class FlutterInappPurchase {
   // Purchase management
   Future<void> requestPurchase(String sku);
   Future<void> requestSubscription(String sku);
-  Future<List<PurchasedItem>?> getAvailablePurchases();
+  Future<List<Purchase>> getAvailablePurchases();
 
   // Transaction management
   Future<String?> finishTransaction(Purchase purchase, {bool isConsumable = false});
@@ -72,20 +72,20 @@ class IapItem {
 }
 ```
 
-### PurchasedItem
+### Purchase
 
 Represents a completed purchase:
 
 ```dart
-class PurchasedItem {
-  final String? productId;
+class Purchase {
+  final String productId;
   final String? transactionId;
-  final DateTime? transactionDate;
+  final int? transactionDate; // timestamp (ms)
   final String? transactionReceipt;
   final String? purchaseToken;
 
   // iOS specific
-  final String? originalTransactionDateIOS;
+  final String? originalTransactionDateIOS; // string
   final String? originalTransactionIdentifierIOS;
 
   // Android specific
@@ -182,7 +182,7 @@ try {
 #### getAvailablePurchases()
 
 ```dart
-Future<List<PurchasedItem>?> getAvailablePurchases() async
+Future<List<Purchase>> getAvailablePurchases() async
 ```
 
 Retrieves all available purchases (including pending and non-consumed).
@@ -294,7 +294,7 @@ Future<List<IapItem>> getProductsIOS(List<String> skus) async
 
 ```dart
 // Get purchase history
-Future<List<PurchasedItem>?> getPurchaseHistoryAndroid() async
+Future<List<Purchase>> getPurchaseHistoryAndroid() async
 
 // Enable debug mode
 void setDebugMode(bool enabled)

--- a/docs/docs/api/types.md
+++ b/docs/docs/api/types.md
@@ -159,31 +159,32 @@ class SubscriptionOfferAndroid {
 
 ## Purchase Types
 
-### PurchasedItem
+### Purchase
 
-Represents a completed purchase.
+Represents a completed purchase (unified across iOS and Android).
 
 ```dart
-class PurchasedItem {
-  final String? productId;                        // Product identifier
-  final String? transactionId;                    // Transaction ID
-  final DateTime? transactionDate;                // Transaction date
-  final String? transactionReceipt;               // Transaction receipt
-  final String? purchaseToken;                    // Unified purchase token (iOS JWS or Android token)
-
-  // Android-specific fields
-  final String? dataAndroid;                      // Purchase data
-  final String? signatureAndroid;                 // Purchase signature
-  final bool? autoRenewingAndroid;               // Auto-renewing status
-  final bool? isAcknowledgedAndroid;             // Acknowledgment status
-  final PurchaseState? purchaseStateAndroid;     // Purchase state
-  final String? purchaseTokenAndroid;            // [DEPRECATED] Use purchaseToken instead
+class Purchase {
+  // Common fields
+  final String productId;                         // Product identifier (SKU)
+  final String? transactionId;                    // Transaction ID (legacy id)
+  final int? transactionDate;                     // Timestamp (ms)
+  final String? transactionReceipt;               // Receipt payload
+  final String? purchaseToken;                    // JWS (iOS) or purchase token (Android)
 
   // iOS-specific fields
-  final DateTime? originalTransactionDateIOS;     // Original transaction date
   final String? originalTransactionIdentifierIOS; // Original transaction ID
-  final TransactionState? transactionStateIOS;   // Transaction state
-  final String? jwsRepresentationIOS;            // [DEPRECATED] Use purchaseToken instead
+  final String? originalTransactionDateIOS;       // Original transaction date (string)
+  final TransactionState? transactionStateIOS;    // Transaction state
+  final String? jwsRepresentationIOS;             // [DEPRECATED] Use purchaseToken
+
+  // Android-specific fields
+  final String? dataAndroid;                      // Raw purchase data
+  final String? signatureAndroid;                 // Signature
+  final bool? autoRenewingAndroid;                // Auto-renewing status
+  final bool? isAcknowledgedAndroid;              // Acknowledgment status
+  final int? purchaseStateAndroid;                // Purchase state
+  final String? purchaseTokenAndroid;             // [DEPRECATED] Use purchaseToken
 }
 ```
 

--- a/docs/docs/api/types/purchase-state.md
+++ b/docs/docs/api/types/purchase-state.md
@@ -71,7 +71,7 @@ enum PurchaseState {
 ### Usage
 
 ```dart
-void handleAndroidPurchase(PurchasedItem item) {
+void handleAndroidPurchase(Purchase item) {
   switch (item.purchaseStateAndroid) {
     case PurchaseState.purchased:
       // Purchase completed - safe to deliver content
@@ -106,7 +106,7 @@ enum TransactionState {
 ### Usage
 
 ```dart
-void handleIOSTransaction(PurchasedItem item) {
+void handleIOSTransaction(Purchase item) {
   switch (item.transactionStateIOS) {
     case TransactionState.purchased:
     case TransactionState.restored:
@@ -136,7 +136,7 @@ void handleIOSTransaction(PurchasedItem item) {
 
 ```dart
 class PurchaseStateHandler {
-  void processPurchase(PurchasedItem purchase) {
+  void processPurchase(Purchase purchase) {
     if (Platform.isAndroid) {
       _handleAndroidPurchase(purchase);
     } else if (Platform.isIOS) {
@@ -144,7 +144,7 @@ class PurchaseStateHandler {
     }
   }
 
-  void _handleAndroidPurchase(PurchasedItem purchase) {
+  void _handleAndroidPurchase(Purchase purchase) {
     switch (purchase.purchaseStateAndroid) {
       case PurchaseState.purchased:
         if (purchase.isAcknowledgedAndroid == false) {
@@ -167,7 +167,7 @@ class PurchaseStateHandler {
     }
   }
 
-  void _handleIOSPurchase(PurchasedItem purchase) {
+  void _handleIOSPurchase(Purchase purchase) {
     switch (purchase.transactionStateIOS) {
       case TransactionState.purchased:
         _deliverContent(purchase);
@@ -309,7 +309,7 @@ bool needsAcknowledgment(Purchase purchase) {
          purchase.isAcknowledgedAndroid == false;
 }
 
-bool canFinishTransaction(PurchasedItem item) {
+bool canFinishTransaction(Purchase item) {
   if (Platform.isIOS) {
     return item.transactionStateIOS == TransactionState.purchased ||
            item.transactionStateIOS == TransactionState.restored ||

--- a/docs/docs/examples/basic-store.md
+++ b/docs/docs/examples/basic-store.md
@@ -248,7 +248,7 @@ class _BasicStoreScreenState extends State<BasicStoreScreen> {
   }
 
   /// Verify purchase with server (mock implementation)
-  Future<bool> _verifyPurchase(PurchasedItem purchase) async {
+  Future<bool> _verifyPurchase(Purchase purchase) async {
     // In a real app, send the receipt to your server for verification
     // For this example, we'll just simulate a successful verification
     await Future.delayed(Duration(milliseconds: 500));
@@ -293,7 +293,7 @@ class _BasicStoreScreenState extends State<BasicStoreScreen> {
   }
 
   /// Finish the transaction
-  Future<void> _finishTransaction(PurchasedItem purchase) async {
+  Future<void> _finishTransaction(Purchase purchase) async {
     try {
       if (Platform.isAndroid) {
         // For Android, consume the purchase if it's a consumable product

--- a/docs/docs/examples/complete-implementation.md
+++ b/docs/docs/examples/complete-implementation.md
@@ -60,7 +60,7 @@ class IAPService {
     }
   }
 
-  void _handlePurchaseUpdate(PurchasedItem? item) async {
+  void _handlePurchaseUpdate(Purchase? item) async {
     if (item == null) return;
 
     try {
@@ -95,7 +95,7 @@ class IAPService {
     }
   }
 
-  void _handlePurchaseError(PurchasedItem? item) {
+  void _handlePurchaseError(Purchase? item) {
     _purchaseController.add(PurchaseUpdate(
       item: item,
       status: PurchaseStatus.error,
@@ -129,7 +129,7 @@ class IAPService {
     await FlutterInappPurchase.instance.requestSubscription(productId);
   }
 
-  Future<List<PurchasedItem>> getAvailablePurchases() async {
+  Future<List<Purchase>> getAvailablePurchases() async {
     try {
       final purchases = await FlutterInappPurchase.instance
           .getAvailablePurchases();
@@ -140,7 +140,7 @@ class IAPService {
     }
   }
 
-  Future<ValidationResult> _validatePurchase(PurchasedItem item) async {
+  Future<ValidationResult> _validatePurchase(Purchase item) async {
     try {
       String? receipt;
 
@@ -177,7 +177,7 @@ class IAPService {
   }
 
   Future<void> _deliverPurchase(
-    PurchasedItem item,
+    Purchase item,
     ValidationResult validationResult
   ) async {
     // Update local storage
@@ -193,7 +193,7 @@ class IAPService {
     );
   }
 
-  Future<void> _completeTransaction(PurchasedItem item) async {
+  Future<void> _completeTransaction(Purchase item) async {
     if (Platform.isIOS) {
       await FlutterInappPurchase.instance.finishTransaction(item);
     } else if (Platform.isAndroid) {
@@ -220,7 +220,7 @@ class IAPService {
 
 // Data models
 class PurchaseUpdate {
-  final PurchasedItem? item;
+  final Purchase? item;
   final PurchaseStatus status;
   final String? error;
   final ValidationResult? validationResult;
@@ -269,7 +269,7 @@ class StoreProvider extends ChangeNotifier {
 
   List<IapItem> _products = [];
   List<IapItem> _subscriptions = [];
-  List<PurchasedItem> _purchases = [];
+  List<Purchase> _purchases = [];
 
   bool _isInitialized = false;
   bool _isLoading = false;
@@ -278,7 +278,7 @@ class StoreProvider extends ChangeNotifier {
   // Getters
   List<IapItem> get products => _products;
   List<IapItem> get subscriptions => _subscriptions;
-  List<PurchasedItem> get purchases => _purchases;
+  List<Purchase> get purchases => _purchases;
   bool get isInitialized => _isInitialized;
   bool get isLoading => _isLoading;
   String? get error => _error;
@@ -363,7 +363,10 @@ class StoreProvider extends ChangeNotifier {
   bool isSubscriptionActive(String productId) {
     final purchase = _purchases.firstWhere(
       (p) => p.productId == productId,
-      orElse: () => PurchasedItem(),
+      orElse: () => Purchase(
+        productId: '',
+        platform: IapPlatform.ios,
+      ),
     );
 
     // Check if subscription is still valid

--- a/docs/docs/examples/subscription-store.md
+++ b/docs/docs/examples/subscription-store.md
@@ -33,7 +33,7 @@ class _SubscriptionStoreState extends State<SubscriptionStore> {
   StreamSubscription? _purchaseErrorSubscription;
 
   List<IapItem> _subscriptions = [];
-  List<PurchasedItem> _purchases = [];
+  List<Purchase> _purchases = [];
   bool _isLoading = true;
 
   // Your subscription IDs
@@ -106,7 +106,7 @@ class _SubscriptionStoreState extends State<SubscriptionStore> {
     }
   }
 
-  void _handlePurchaseUpdate(PurchasedItem? item) async {
+  void _handlePurchaseUpdate(Purchase? item) async {
     if (item == null) return;
 
     print('Purchase update: ${item.productId}');
@@ -134,7 +134,7 @@ class _SubscriptionStoreState extends State<SubscriptionStore> {
     }
   }
 
-  void _handlePurchaseError(PurchasedItem? item) {
+  void _handlePurchaseError(Purchase? item) {
     // Handle purchase errors
     _showError('Purchase failed');
   }
@@ -159,18 +159,18 @@ class _SubscriptionStoreState extends State<SubscriptionStore> {
     }
   }
 
-  Future<bool> _verifyPurchase(PurchasedItem item) async {
+  Future<bool> _verifyPurchase(Purchase item) async {
     // TODO: Implement server-side verification
     // This should verify the receipt with your backend
     return true;
   }
 
-  Future<void> _deliverSubscription(PurchasedItem item) async {
+  Future<void> _deliverSubscription(Purchase item) async {
     // TODO: Grant subscription access to user
     print('Delivering subscription: ${item.productId}');
   }
 
-  Future<void> _completeTransaction(PurchasedItem item) async {
+  Future<void> _completeTransaction(Purchase item) async {
     if (Platform.isIOS) {
       await FlutterInappPurchase.instance.finishTransaction(item);
     } else if (Platform.isAndroid) {

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -161,7 +161,7 @@ Future<void> restorePurchases() async {
 **A:** Android purchases can be pending for various payment methods:
 
 ```dart
-void _handlePurchaseUpdate(PurchasedItem item) {
+void _handlePurchaseUpdate(Purchase item) {
   if (item.purchaseStateAndroid == 0) {
     // Purchase completed
     _deliverProduct(item);

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -26,7 +26,7 @@ class _SimpleStoreState extends State<SimpleStore> {
 
   List<ProductCommon> _products = [];
   List<ProductCommon> _subscriptions = [];
-  List<PurchasedItem> _purchases = [];
+  List<Purchase> _purchases = [];
 
   // Your product IDs from App Store Connect / Google Play Console
   final List<String> _productIds = [
@@ -108,7 +108,7 @@ class _SimpleStoreState extends State<SimpleStore> {
   // Get previous purchases
   Future<void> _getPurchases() async {
     try {
-      List<PurchasedItem>? purchases =
+      List<Purchase>? purchases =
           await FlutterInappPurchase.instance.getAvailablePurchases();
 
       setState(() {
@@ -120,7 +120,7 @@ class _SimpleStoreState extends State<SimpleStore> {
   }
 
   // Handle purchase updates
-  void _handlePurchaseUpdate(PurchasedItem productItem) async {
+  void _handlePurchaseUpdate(Purchase productItem) async {
     // Verify purchase on your server here
     bool isValid = await _verifyPurchase(productItem);
 
@@ -188,14 +188,14 @@ class _SimpleStoreState extends State<SimpleStore> {
   }
 
   // Verify purchase (implement your server logic)
-  Future<bool> _verifyPurchase(PurchasedItem item) async {
+  Future<bool> _verifyPurchase(Purchase item) async {
     // TODO: Verify receipt with your server
     // For now, just return true
     return true;
   }
 
   // Deliver product (implement your logic)
-  Future<void> _deliverProduct(PurchasedItem item) async {
+  Future<void> _deliverProduct(Purchase item) async {
     // TODO: Deliver the product to user
     print('Delivering product: ${item.productId}');
   }

--- a/docs/docs/guides/basic-setup.md
+++ b/docs/docs/guides/basic-setup.md
@@ -43,7 +43,7 @@ class IAPService {
   IAPService._internal();
 
   // Stream subscriptions
-  StreamSubscription<PurchasedItem?>? _purchaseSubscription;
+  StreamSubscription<Purchase?>? _purchaseSubscription;
   StreamSubscription<PurchaseResult?>? _errorSubscription;
 
   // Connection state
@@ -107,7 +107,7 @@ class IAPService {
   }
 
   /// Handle successful purchase updates
-  Future<void> _handlePurchaseUpdate(PurchasedItem purchase) async {
+  Future<void> _handlePurchaseUpdate(Purchase purchase) async {
     print('🎉 Purchase received: ${purchase.productId}');
 
     try {
@@ -160,7 +160,7 @@ class IAPService {
   }
 
   /// Verify purchase with your server
-  Future<bool> _verifyPurchase(PurchasedItem purchase) async {
+  Future<bool> _verifyPurchase(Purchase purchase) async {
     // TODO: Implement server-side verification
     // This is crucial for security!
 
@@ -170,7 +170,7 @@ class IAPService {
   }
 
   /// Grant purchased content to the user
-  Future<void> _grantPurchasedContent(PurchasedItem purchase) async {
+  Future<void> _grantPurchasedContent(Purchase purchase) async {
     final productId = purchase.productId ?? '';
 
     // Grant content based on product ID

--- a/docs/docs/guides/faq.md
+++ b/docs/docs/guides/faq.md
@@ -186,7 +186,7 @@ Receipt validation should always be done server-side:
 ```dart
 class ReceiptValidator {
   // iOS Receipt Validation
-  Future<bool> validateIOSReceipt(PurchasedItem purchase) async {
+  Future<bool> validateIOSReceipt(Purchase purchase) async {
     if (purchase.transactionReceipt == null) return false;
 
     final response = await http.post(
@@ -204,7 +204,7 @@ class ReceiptValidator {
   }
 
   // Android Receipt Validation
-  Future<bool> validateAndroidReceipt(PurchasedItem purchase) async {
+  Future<bool> validateAndroidReceipt(Purchase purchase) async {
     if (purchase.purchaseToken == null) return false;
 
     final response = await http.post(
@@ -347,13 +347,13 @@ class ProductIds {
 
 ```dart
 // ❌ Don't do this - Client-side only
-void badPractice(PurchasedItem purchase) {
+void badPractice(Purchase purchase) {
   // Directly deliver content without verification
   deliverContent(purchase.productId);
 }
 
 // ✅ Do this - Server-side verification
-Future<void> goodPractice(PurchasedItem purchase) async {
+Future<void> goodPractice(Purchase purchase) async {
   // 1. Send to server for verification
   final isValid = await verifyOnServer(purchase);
 
@@ -754,7 +754,7 @@ class PerformanceOptimization {
     });
   }
 
-  static void _processPurchaseImmediately(PurchasedItem purchase) {
+  static void _processPurchaseImmediately(Purchase purchase) {
     // Implementation for immediate purchase processing
   }
 

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -166,7 +166,7 @@ class PurchaseScreen extends StatefulWidget {
 class _PurchaseScreenState extends State<PurchaseScreen>
     with WidgetsBindingObserver {
 
-  StreamSubscription<PurchasedItem?>? _purchaseSubscription;
+  StreamSubscription<Purchase?>? _purchaseSubscription;
   StreamSubscription<PurchaseResult?>? _errorSubscription;
   bool _isProcessing = false;
 
@@ -234,11 +234,11 @@ Using hooks or similar patterns for functional components:
 ```dart
 // Custom hook for IAP lifecycle management
 class IapHook {
-  late StreamSubscription<PurchasedItem?>? _purchaseSubscription;
+  late StreamSubscription<Purchase?>? _purchaseSubscription;
   late StreamSubscription<PurchaseResult?>? _errorSubscription;
 
   void initialize(
-    Function(PurchasedItem) onPurchase,
+    Function(Purchase) onPurchase,
     Function(PurchaseResult) onError,
   ) {
     _purchaseSubscription = FlutterInappPurchase.purchaseUpdated.listen(
@@ -336,7 +336,7 @@ Always validate purchases server-side:
 
 ```dart
 class SecurePurchaseValidator {
-  static Future<bool> validatePurchase(PurchasedItem purchase) async {
+  static Future<bool> validatePurchase(Purchase purchase) async {
     try {
       if (Platform.isIOS) {
         // iOS receipt validation
@@ -552,7 +552,7 @@ class TransactionCleanup {
     }
   }
 
-  static Future<void> _finalizePurchase(PurchasedItem purchase) async {
+  static Future<void> _finalizePurchase(Purchase purchase) async {
     // Validate and deliver content first
     final isValid = await _validatePurchase(purchase);
     if (!isValid) return;
@@ -581,7 +581,7 @@ class TransactionCleanup {
 ```dart
 // Solution: Always validate server-side
 class SecurityBestPractices {
-  static Future<bool> secureValidation(PurchasedItem purchase) async {
+  static Future<bool> secureValidation(Purchase purchase) async {
     // 1. Client-side basic checks
     if (purchase.productId == null || purchase.transactionReceipt == null) {
       return false;

--- a/docs/docs/guides/offer-code-redemption.md
+++ b/docs/docs/guides/offer-code-redemption.md
@@ -68,7 +68,7 @@ class OfferCodeHandler {
     });
   }
   
-  void _handleRedeemedPurchase(PurchasedItem purchase) {
+  void _handleRedeemedPurchase(Purchase purchase) {
     // Process the redeemed purchase
     // Verify receipt, deliver content, etc.
   }

--- a/docs/docs/guides/products.md
+++ b/docs/docs/guides/products.md
@@ -102,7 +102,7 @@ class ProductStore {
     }
   }
 
-  void handlePurchaseUpdate(PurchasedItem item) async {
+  void handlePurchaseUpdate(Purchase item) async {
     // 1. Verify the purchase
     bool isValid = await verifyPurchase(item);
 
@@ -150,7 +150,7 @@ await FlutterInappPurchase.instance.acknowledgePurchase(
 Basic validation before server verification:
 
 ```dart
-bool validatePurchaseLocally(PurchasedItem item) {
+bool validatePurchaseLocally(Purchase item) {
   // Check required fields
   if (item.productId == null || item.transactionId == null) {
     return false;
@@ -180,7 +180,7 @@ bool validatePurchaseLocally(PurchasedItem item) {
 Always verify purchases on your server:
 
 ```dart
-Future<bool> verifyPurchase(PurchasedItem item) async {
+Future<bool> verifyPurchase(Purchase item) async {
   // Get receipt data
   String? receipt;
   if (Platform.isIOS) {
@@ -213,7 +213,7 @@ class ConsumableManager {
   // Track consumable inventory
   Map<String, int> inventory = {};
 
-  Future<void> handleConsumablePurchase(PurchasedItem item) async {
+  Future<void> handleConsumablePurchase(Purchase item) async {
     // Add to inventory
     String productId = item.productId!;
     int amount = getProductAmount(productId);
@@ -252,7 +252,7 @@ class ConsumableManager {
 class NonConsumableManager {
   Set<String> unlockedFeatures = {};
 
-  Future<void> handleNonConsumablePurchase(PurchasedItem item) async {
+  Future<void> handleNonConsumablePurchase(Purchase item) async {
     // Unlock the feature
     unlockedFeatures.add(item.productId!);
 
@@ -285,7 +285,7 @@ Always provide a way to restore non-consumable purchases:
 ```dart
 Future<void> restorePurchases() async {
   try {
-    List<PurchasedItem>? purchases = await FlutterInappPurchase
+    List<Purchase>? purchases = await FlutterInappPurchase
         .instance.getAvailablePurchases();
 
     if (purchases != null) {

--- a/docs/docs/guides/purchases.md
+++ b/docs/docs/guides/purchases.md
@@ -52,16 +52,16 @@ class PurchaseHandler {
   // Using singleton instance for in-app purchases
   final _iap = FlutterInappPurchase.instance;
 
-  StreamSubscription<PurchasedItem?>? _purchaseUpdatedSubscription;
+  StreamSubscription<Purchase?>? _purchaseUpdatedSubscription;
   StreamSubscription<PurchaseResult?>? _purchaseErrorSubscription;
 
   void setupPurchaseListeners() {
     // Listen to successful purchases
     _purchaseUpdatedSubscription = _iap.purchaseUpdated.listen(
-      (purchasedItem) {
-        if (purchasedItem != null) {
-          debugPrint('Purchase update received: ${purchasedItem.productId}');
-          _handlePurchaseUpdate(purchasedItem);
+      (purchase) {
+        if (purchase != null) {
+          debugPrint('Purchase update received: ${purchase.productId}');
+          _handlePurchaseUpdate(purchase);
         }
       },
     );
@@ -102,7 +102,7 @@ class _ProductsScreenState extends State<ProductsScreen> {
 
   String? _purchaseResult;
   bool _isProcessing = false;
-  StreamSubscription<PurchasedItem?>? _purchaseUpdatedSubscription;
+  StreamSubscription<Purchase?>? _purchaseUpdatedSubscription;
   StreamSubscription<PurchaseResult?>? _purchaseErrorSubscription;
 
   @override
@@ -234,7 +234,7 @@ await FlutterInappPurchase.instance.requestSubscription(productId);
 Handle cases where purchases might be pending:
 
 ```dart
-Future<void> _handlePurchaseUpdate(PurchasedItem purchasedItem) async {
+Future<void> _handlePurchaseUpdate(Purchase purchasedItem) async {
   debugPrint('Purchase successful: ${purchasedItem.productId}');
 
   // Deliver the product to the user
@@ -351,7 +351,7 @@ void checkPlatformFeatures() {
 Products that can be purchased multiple times:
 
 ```dart
-Future<void> handleConsumableProduct(PurchasedItem purchase) async {
+Future<void> handleConsumableProduct(Purchase purchase) async {
   // Deliver the consumable content (coins, lives, etc.)
   await deliverConsumableProduct(purchase.productId);
 
@@ -377,7 +377,7 @@ Future<void> handleConsumableProduct(PurchasedItem purchase) async {
 Products purchased once and owned permanently:
 
 ```dart
-Future<void> handleNonConsumableProduct(PurchasedItem purchase) async {
+Future<void> handleNonConsumableProduct(Purchase purchase) async {
   // Deliver the permanent content (premium features, ad removal)
   await deliverPermanentProduct(purchase.productId);
 
@@ -403,7 +403,7 @@ Future<void> handleNonConsumableProduct(PurchasedItem purchase) async {
 Recurring purchases with auto-renewal:
 
 ```dart
-Future<void> handleSubscriptionProduct(PurchasedItem purchase) async {
+Future<void> handleSubscriptionProduct(Purchase purchase) async {
   // Activate subscription for user
   await activateSubscription(purchase.productId);
 
@@ -518,7 +518,7 @@ Future<void> openSubscriptionManagement() async {
 Validate purchases server-side for security:
 
 ```dart
-Future<bool> validatePurchaseReceipt(PurchasedItem purchase) async {
+Future<bool> validatePurchaseReceipt(Purchase purchase) async {
   try {
     if (Platform.isIOS) {
       // Validate iOS receipt
@@ -638,7 +638,7 @@ Here's a complete working example based on the project's `products_screen.dart`:
 class PurchaseService {
   final _iap = FlutterInappPurchase.instance;
 
-  StreamSubscription<PurchasedItem?>? _purchaseUpdatedSubscription;
+  StreamSubscription<Purchase?>? _purchaseUpdatedSubscription;
   StreamSubscription<PurchaseResult?>? _purchaseErrorSubscription;
 
   void init() {
@@ -663,7 +663,7 @@ class PurchaseService {
     );
   }
 
-  Future<void> _handlePurchaseSuccess(PurchasedItem purchase) async {
+  Future<void> _handlePurchaseSuccess(Purchase purchase) async {
     // 1. Deliver product
     await _deliverProduct(purchase.productId);
 

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -77,7 +77,7 @@ purchase.jwsRepresentationIOS; // [DEPRECATED] Use purchaseToken instead
 
 ```dart
 // Cross-platform server validation
-void validatePurchase(PurchasedItem purchase) {
+void validatePurchase(Purchase purchase) {
   final token = purchase.purchaseToken; // Works on both iOS & Android
 
   if (purchase.platform == IapPlatform.ios) {

--- a/docs/docs/migration/from-expo-iap.md
+++ b/docs/docs/migration/from-expo-iap.md
@@ -158,7 +158,7 @@ Future<void> _requestPurchase(String productId) async {
 }
 
 // Handle purchase completion
-void _handlePurchaseUpdate(PurchasedItem item) async {
+void _handlePurchaseUpdate(Purchase item) async {
   // Deliver content
   await _deliverProduct(item);
 
@@ -218,10 +218,10 @@ interface Purchase {
 }
 ```
 
-**flutter_inapp_purchase PurchasedItem:**
+**flutter_inapp_purchase Purchase:**
 
 ```dart
-class PurchasedItem {
+class Purchase {
   String? productId;           // maps to id
   String? transactionId;       // same
   int? transactionDate;        // same (timestamp)
@@ -363,7 +363,7 @@ class _StoreState extends State<Store> {
     }
   }
 
-  void _handlePurchase(PurchasedItem? item) async {
+  void _handlePurchase(Purchase? item) async {
     if (item == null) return;
 
     try {

--- a/docs/docs/migration/from-v5.md
+++ b/docs/docs/migration/from-v5.md
@@ -291,7 +291,7 @@ class _MyAppState extends State<MyApp> {
   StreamSubscription _purchaseUpdatedSubscription;
   StreamSubscription _purchaseErrorSubscription;
   List<IAPItem> _items = [];
-  List<PurchasedItem> _purchases = [];
+  List<Purchase> _purchases = [];
 
   @override
   void initState() {
@@ -336,7 +336,7 @@ class _MyAppState extends State<MyApp> {
   StreamSubscription? _purchaseUpdatedSubscription;
   StreamSubscription? _purchaseErrorSubscription;
   List<IapItem> _items = [];
-  List<PurchasedItem> _purchases = [];
+  List<Purchase> _purchases = [];
 
   @override
   void initState() {
@@ -365,8 +365,8 @@ class _MyAppState extends State<MyApp> {
     });
 
     _purchaseErrorSubscription = FlutterInappPurchase
-        .purchaseError.listen((productItem) {
-      print('purchase-error: ${productItem?.productId}');
+        .purchaseError.listen((result) {
+      print('purchase-error: ${result?.message}');
       // Handle error
     });
 
@@ -381,7 +381,7 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  Future<void> _finishTransaction(PurchasedItem item) async {
+  Future<void> _finishTransaction(Purchase item) async {
     try {
       await FlutterInappPurchase.instance.finishTransaction(item);
     } catch (e) {

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -201,12 +201,12 @@ flutter pub upgrade
 3. **Check purchase listeners:**
    ```dart
    // Ensure listeners are set up before purchase
-   FlutterInappPurchase.purchaseUpdated.listen((item) {
-     print('Purchase updated: ${item?.productId}');
+   FlutterInappPurchase.purchaseUpdated.listen((purchase) {
+     print('Purchase updated: ${purchase?.productId}');
    });
    
-   FlutterInappPurchase.purchaseError.listen((item) {
-     print('Purchase error: ${item?.productId}');
+   FlutterInappPurchase.purchaseError.listen((result) {
+     print('Purchase error: ${result?.message}');
    });
    ```
 
@@ -216,22 +216,22 @@ flutter pub upgrade
 
 **Solution:**
 ```dart
-void _handlePurchaseUpdate(PurchasedItem? item) async {
-  if (item == null) return;
+void _handlePurchaseUpdate(Purchase? purchase) async {
+  if (purchase == null) return;
   
   try {
     // IMPORTANT: Always complete transactions
     if (Platform.isIOS) {
-      await FlutterInappPurchase.instance.finishTransaction(item);
+      await FlutterInappPurchase.instance.finishTransaction(purchase);
     } else {
       // Android: Choose based on product type
-      if (isConsumable(item.productId!)) {
+      if (isConsumable(purchase.productId)) {
         await FlutterInappPurchase.instance.consumePurchase(
-          purchaseToken: item.purchaseToken!,
+          purchaseToken: purchase.purchaseToken!,
         );
       } else {
         await FlutterInappPurchase.instance.acknowledgePurchase(
-          purchaseToken: item.purchaseToken!,
+          purchaseToken: purchase.purchaseToken!,
         );
       }
     }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -1331,7 +1331,7 @@ class FlutterInappPurchase
     );
   }
 
-  /// Finish a transaction using PurchasedItem object (legacy compatibility)
+  /// Finish a transaction using legacy PurchasedItem JSON (legacy compatibility)
   /// @deprecated Use finishTransaction with Purchase object instead
   Future<void> finishTransactionIOS(
     Map<String, dynamic> purchasedItemJson, {

--- a/lib/types.dart
+++ b/lib/types.dart
@@ -1636,6 +1636,16 @@ class Purchase {
   /// OpenIAP compatibility: ids array containing the productId
   List<String> get ids => [productId];
 
+  /// Common quantity field (OpenIAP compliant)
+  /// iOS supports quantity; Android defaults to 1
+  int get quantity => quantityIOS ?? 1;
+
+  /// Common auto-renew flag across platforms
+  bool get isAutoRenewing =>
+      autoRenewing == true ||
+      autoRenewingAndroid == true ||
+      isAutoRenewingAndroid == true;
+
   Purchase({
     required this.productId,
     required this.platform,


### PR DESCRIPTION
Complete migration from PurchasedItem to Purchase across current docs and examples. Add Purchase.quantity and Purchase.isAutoRenewing getters to align with unified types and simplify API usage across platforms.

Leave versioned docs unchanged for historical accuracy.

Closes #552