### PR TITLE
fix(ios): add missing isEligibleForIntroOffer method

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -26,7 +26,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_inapp_purchase: e7ef664bd118628b86ba8b42f8a5b7f51f1914ac
+  flutter_inapp_purchase: 08cad8b094e45655f438524caa5f5ae8d6ff7850
   openiap: baba2fe783a58613bdf2d3dbb47dec8ac9cf72de
 
 PODFILE CHECKSUM: 87f97a09c4d988218d5797585f3b888e2cb6cfb1

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -595,7 +595,7 @@ class FlutterInappPurchase with RequestPurchaseBuilderApi {
 
             try {
               final result = await _channel.invokeMethod<bool>(
-                'isEligibleForIntroOffer',
+                'isEligibleForIntroOfferIOS',
                 {'productId': groupId},
               );
               return result ?? false;

--- a/test/ios_methods_test.dart
+++ b/test/ios_methods_test.dart
@@ -48,7 +48,7 @@ void main() {
                   'isAutoRenewing': false,
                 },
               };
-            case 'isEligibleForIntroOffer':
+            case 'isEligibleForIntroOfferIOS':
               return true;
             case 'getSubscriptionStatus':
               return <Map<String, dynamic>>[
@@ -260,7 +260,7 @@ void main() {
 
     test('isEligibleForIntroOfferIOS returns platform result', () async {
       expect(await iap.isEligibleForIntroOfferIOS('group'), isTrue);
-      expect(calls.last.method, 'isEligibleForIntroOffer');
+      expect(calls.last.method, 'isEligibleForIntroOfferIOS');
     });
 
     test('isEligibleForIntroOfferIOS returns false on non-iOS', () async {

--- a/test/ios_module_methods_test.dart
+++ b/test/ios_module_methods_test.dart
@@ -22,7 +22,7 @@ void main() {
           case 'endConnection':
           case 'initConnection':
             return true;
-          case 'isEligibleForIntroOffer':
+          case 'isEligibleForIntroOfferIOS':
             return true;
           case 'getSubscriptionStatus':
             return <Map<String, dynamic>>[


### PR DESCRIPTION
Resolve #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added iOS support to check a user’s eligibility for introductory offers. Provides clear errors when required inputs are missing and consistent async behavior with other purchase flows.

- Tests
  - Updated test coverage to validate the new iOS intro-offer eligibility path and ensure correct method routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->